### PR TITLE
Disable max concurrency and max partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,6 @@ KAFKA=localhost:9092 poetry run pytest tests
 (or a todo here)
 
 - [x] worker
-- [ ] auto scaling/concurrency
-    - automatically increase concurrency
-    - automatically increase number of partitions
 - [ ] service to inspect stats
 - [ ] be able to handle manual commit use-case
 - [ ] be able to reject commit/abort message handling

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -33,14 +33,10 @@ logger = logging.getLogger("kafkaesk")
 
 
 class Subscription:
-    def __init__(
-        self, stream_id: str, func: Callable, group: str, max_partitions: int, max_concurrency: int
-    ):
+    def __init__(self, stream_id: str, func: Callable, group: str):
         self.stream_id = stream_id
         self.func = func
         self.group = group
-        self.max_partitions = max_partitions
-        self.max_concurrency = max_concurrency
 
     def __repr__(self) -> str:
         return f"<Subscription stream: {self.stream_id} >"
@@ -262,21 +258,9 @@ class Application:
         if self._producer is not None:
             await self._producer.flush()
 
-    def subscribe(
-        self,
-        stream_id: str,
-        group: Optional[str] = None,
-        max_partitions: int = 40,
-        max_concurrency: int = 3,
-    ) -> Callable:
+    def subscribe(self, stream_id: str, group: Optional[str] = None,) -> Callable:
         def inner(func: Callable) -> Callable:
-            subscription = Subscription(
-                stream_id,
-                func,
-                group or func.__name__,
-                max_partitions=max_partitions,
-                max_concurrency=max_concurrency,
-            )
+            subscription = Subscription(stream_id, func, group or func.__name__)
             self._subscriptions.append(subscription)
             return func
 


### PR DESCRIPTION
There is no yet a use case for implementing both parameters, and in both
use case the prescripted way for ahiving max concurrency is through horizontal
scaling, by adding more instances, and by defining beforehand the maximum number
of partitions considering the traffic that you would be handling.