### PR TITLE
Update kafkaesk handler queue to create queue as late as possible

### DIFF
--- a/tests/ext/logging/test_handler.py
+++ b/tests/ext/logging/test_handler.py
@@ -154,6 +154,7 @@ class TestKafkaeskQueue:
     async def test_queue_flush(self, app, queue, log_consumer):
 
         async with app:
+            queue.start()
             for i in range(10):
                 queue.put_nowait("log.test", PydanticLogModel(count=i))
 
@@ -198,6 +199,7 @@ class TestKafkaeskQueue:
     @pytest.mark.with_max_queue(1)
     async def test_queue_max_size(self, app, queue):
 
+        queue.start()
         queue.put_nowait("log.test", PydanticLogModel())
 
         with pytest.raises(asyncio.QueueFull):


### PR DESCRIPTION
In some cases, the asyncio queue object was being created with the wrong event loop.  This should ensure that the same event loop will be used for the queue as well as the worker that consumes the queue.  Both of these objects are created with the first log message to push back instantiation time as late as possible to ensure we are on the correct event loop.