### PR TITLE
Implement interface for consumer Retry Policies

### DIFF
--- a/kafkaesk/__init__.py
+++ b/kafkaesk/__init__.py
@@ -2,5 +2,7 @@ from .app import Application  # noqa
 from .app import Router  # noqa
 from .app import run  # noqa
 from .app import run_app  # noqa
+from .retry import get_default_retry_policy  # noqa
+from .retry import set_default_retry_policy  # noqa
 
 __version__ = "0.1.33"

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -265,6 +265,8 @@ class SubscriptionConsumer:
                     context.close()
                     await self.emit("message", record=record)
         finally:
+            # Shutdown the retry policy
+            await retry_policy.finalize()
             try:
                 await self._consumer.commit()
             except Exception:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -258,7 +258,11 @@ class SubscriptionConsumer:
                         error="UnhandledMessage",
                         group_id=self._subscription.group,
                     ).inc()
-                    await retry_policy(record=record, error=err)
+                    try:
+                        await retry_policy(record=record, error=err)
+                    except UnhandledMessage:
+                        # Do not allow this exception up the stack if it is re-raised
+                        ...
                 except Exception as err:
                     CONSUMED_MESSAGES.labels(
                         stream_id=record.topic,

--- a/kafkaesk/metrics.py
+++ b/kafkaesk/metrics.py
@@ -44,11 +44,13 @@ CONSUMER_REBALANCED = client.Counter(
 )
 
 MESSAGE_FAILED = client.Counter(
-    "kafkaesk_consumer_message_failed", "Failed Messages", ["stream_id", "group_id", "partition"],
+    "kafkaesk_consumer_message_failed",
+    "Failed Messages",
+    ["stream_id", "group_id", "partition", "error"],
 )
 
 MESSAGE_REQUEUED = client.Counter(
     "kafkaesk_consumer_message_requeued",
     "Requeued Messages",
-    ["stream_id", "group_id", "partition"],
+    ["stream_id", "group_id", "partition", "error"],
 )

--- a/kafkaesk/metrics.py
+++ b/kafkaesk/metrics.py
@@ -42,3 +42,13 @@ MESSAGE_LEAD_TIME = client.Histogram(
 CONSUMER_REBALANCED = client.Counter(
     "kafkaesk_consumer_rebalanced", "Consumer rebalances", ["stream_id", "group_id", "partition"],
 )
+
+MESSAGE_FAILED = client.Counter(
+    "kafkaesk_consumer_message_failed", "Failed Messages", ["stream_id", "group_id", "partition"],
+)
+
+MESSAGE_REQUEUED = client.Counter(
+    "kafkaesk_consumer_message_requeued",
+    "Requeued Messages",
+    ["stream_id", "group_id", "partition"],
+)

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -113,7 +113,7 @@ class RetryPolicy(ABC):
             raise RuntimeError("RetryPolicy is not initialized")
 
         if self._should_requeue(record, error):
-            return await self._handle_retry(record, error)
+            return await self._handle_requeue(record, error)
         else:
             return await self._handle_failure(record, error)
 
@@ -126,7 +126,7 @@ class RetryPolicy(ABC):
 
         return self.should_requeue(record, error)
 
-    async def _handle_retry(self, record: ConsumerRecord, error: Exception) -> None:
+    async def _handle_requeue(self, record: ConsumerRecord, error: Exception) -> None:
         MESSAGE_REQUEUED.labels(
             stream_id=record.topic,
             partition=record.partition,
@@ -134,7 +134,7 @@ class RetryPolicy(ABC):
             group_id=self._subscription.group,
         ).inc()
 
-        await self.handle_retry(record, error)
+        await self.handle_requeue(record, error)
 
     async def _handle_failure(self, record: ConsumerRecord, error: Exception) -> None:
         MESSAGE_FAILED.labels(
@@ -149,7 +149,7 @@ class RetryPolicy(ABC):
     def should_requeue(self, record: ConsumerRecord, error: Exception) -> bool:
         raise NotImplementedError
 
-    async def handle_retry(self, record: ConsumerRecord, error: Exception) -> None:
+    async def handle_requeue(self, record: ConsumerRecord, error: Exception) -> None:
         raise NotImplementedError
 
     async def handle_failure(self, record: ConsumerRecord, error: Exception) -> None:

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -1,0 +1,86 @@
+from .app import Application
+from .app import Subscription
+from .app import SubscriptionConsumer
+from abc import ABC
+from kafka.consumer.fetcher import ConsumerRecord
+from pydantic import BaseModel
+
+import datetime
+
+
+class RetryInfo(BaseModel):
+    retry_count: int
+    retry_delay: int = 0
+    retry_timestamp: datetime.datetime
+    publish_timestamp: datetime.datetime
+    publish_topic: str
+    error: Exception
+
+
+class RertyMessage(BaseModel):
+    retry_info: RetryInfo
+    original_message: ConsumerRecord
+
+
+class FailureInfo(BaseModel):
+    retry_count: int
+    failure_timestamp: datetime.datetime
+    publish_topic: str
+    error: Exception
+
+
+class FailureMessage(BaseModel):
+    failure_info: FailureInfo
+    original_message: ConsumerRecord
+
+
+class RetryPolicy(ABC):
+    def __init__(self) -> None:
+        self._initialized = False
+
+    async def initialize(
+        self, app: Application, subscription: Subscription, consumer: SubscriptionConsumer
+    ) -> None:
+
+        self._app = app
+        self._subscription = subscription
+        self._consumer = consumer
+
+        self._finalized = True
+
+    async def finalize(self) -> None:
+        self._finalized = False
+
+    async def handle(self, message: ConsumerRecord, error: Exception) -> None:
+        if self._initialized is not True:
+            raise RuntimeError("RetryPolicy is not initialized")
+
+        return await self._handle(message, error)
+
+    async def _handle(self, message: ConsumerRecord, error: Exception) -> None:
+        raise NotImplementedError
+
+
+class NoRetry(RetryPolicy):
+    async def initialize(
+        self, app: Application, subscription: Subscription, consumer: SubscriptionConsumer
+    ) -> None:
+        super().initialize(app, subscription, consumer)
+
+        # Setup failure topic
+        self.failure_topic = f"{subscription.group}:{subscription.stream_id}"
+
+    async def finalize(self) -> None:
+        pass
+
+    async def _handle(self, message: ConsumerRecord, error: Exception) -> None:
+
+        info = FailureInfo(
+            retry_count=0,
+            failure_timestamp=datetime.datetime.now(),
+            publish_topic=self._subscription.stream_id,
+            error=error,
+        )
+        await self._app.publish(
+            self.failure_topic, FailureMessage(failure_info=info, original_message=message)
+        )

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -1,9 +1,11 @@
 from .app import Application
 from .app import Subscription
-from .app import SubscriptionConsumer
+from .metrics import MESSAGE_FAILED
+from .metrics import MESSAGE_REQUEUED
 from abc import ABC
-from kafka.consumer.fetcher import ConsumerRecord
+from aiokafka.structs import ConsumerRecord
 from pydantic import BaseModel
+from typing import Callable
 
 import datetime
 
@@ -17,9 +19,9 @@ class RetryInfo(BaseModel):
     error: Exception
 
 
-class RertyMessage(BaseModel):
+class RetryMessage(BaseModel):
     retry_info: RetryInfo
-    original_message: ConsumerRecord
+    original_record: ConsumerRecord
 
 
 class FailureInfo(BaseModel):
@@ -31,49 +33,81 @@ class FailureInfo(BaseModel):
 
 class FailureMessage(BaseModel):
     failure_info: FailureInfo
-    original_message: ConsumerRecord
+    original_record: ConsumerRecord
 
 
 class RetryPolicy(ABC):
     def __init__(self) -> None:
         self._initialized = False
 
-    async def initialize(
-        self, app: Application, subscription: Subscription, consumer: SubscriptionConsumer
-    ) -> None:
+    async def initialize(self, app: Application, subscription: Subscription) -> None:
 
         self._app = app
         self._subscription = subscription
-        self._consumer = consumer
 
         self._finalized = True
 
     async def finalize(self) -> None:
         self._finalized = False
 
-    async def handle(self, message: ConsumerRecord, error: Exception) -> None:
+    async def __call__(self, record: ConsumerRecord, error: Exception) -> None:
         if self._initialized is not True:
             raise RuntimeError("RetryPolicy is not initialized")
 
-        return await self._handle(message, error)
+        if self.should_retry(record, error):
+            return await self._handle_retry(record, error)
+        else:
+            return await self._handle_failure(record, error)
 
-    async def _handle(self, message: ConsumerRecord, error: Exception) -> None:
+    async def _handle_retry(self, record: ConsumerRecord, error: Exception) -> None:
+        await self.handle_retry(record, error)
+
+        MESSAGE_REQUEUED.labels(
+            stream_id=record.topic,
+            partition=record.partition,
+            error="UnhandledMessage",
+            group_id=self._subscription.group,
+        ).inc()
+
+    async def _handle_failure(self, record: ConsumerRecord, error: Exception) -> None:
+        await self.handle_failure(record, error)
+
+        MESSAGE_FAILED.labels(
+            stream_id=record.topic,
+            partition=record.partition,
+            error="UnhandledMessage",
+            group_id=self._subscription.group,
+        ).inc()
+
+    def should_retry(self, record: ConsumerRecord, error: Exception) -> bool:
+        raise NotImplementedError
+
+    async def handle_retry(self, record: ConsumerRecord, error: Exception) -> None:
+        raise NotImplementedError
+
+    async def handle_failure(self, record: ConsumerRecord, error: Exception) -> None:
         raise NotImplementedError
 
 
 class NoRetry(RetryPolicy):
-    async def initialize(
-        self, app: Application, subscription: Subscription, consumer: SubscriptionConsumer
-    ) -> None:
-        super().initialize(app, subscription, consumer)
+    def should_retry(self, record: ConsumerRecord, error: Exception) -> bool:
+        return False
+
+    async def _handle_failure(self, record: ConsumerRecord, error: Exception) -> None:
+        raise error
+
+
+class Forward(RetryPolicy):
+    async def initialize(self, app: Application, subscription: Subscription) -> None:
+        super().initialize(app, subscription)
 
         # Setup failure topic
         self.failure_topic = f"{subscription.group}:{subscription.stream_id}"
 
-    async def finalize(self) -> None:
-        pass
+    def should_retry(self, record: ConsumerRecord, error: Exception) -> bool:
+        return False
 
-    async def _handle(self, message: ConsumerRecord, error: Exception) -> None:
+    async def _handle_failure(self, record: ConsumerRecord, error: Exception) -> None:
 
         info = FailureInfo(
             retry_count=0,
@@ -82,5 +116,21 @@ class NoRetry(RetryPolicy):
             error=error,
         )
         await self._app.publish(
-            self.failure_topic, FailureMessage(failure_info=info, original_message=message)
+            self.failure_topic, FailureMessage(failure_info=info, original_record=record)
         )
+
+
+DefaultRetryPolicyFactory = Callable[..., RetryPolicy]
+
+_default_retry_policy: DefaultRetryPolicyFactory = NoRetry
+
+
+def get_default_retry_policy() -> DefaultRetryPolicyFactory:
+    global _default_retry_policy
+
+    return _default_retry_policy
+
+
+def set_default_retry_policy(policy: DefaultRetryPolicyFactory) -> None:
+    global _default_retry_policy
+    _default_retry_policy = policy

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,7 +9,7 @@ async def kafka():
     yield os.environ.get("KAFKA", "localhost:9092").split(":")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 async def app(kafka):
     yield kafkaesk.Application(
         [f"{kafka[0]}:{kafka[1]}"],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,6 +53,20 @@ def test_mount_router(app):
     assert app.event_handlers == router.event_handlers
 
 
+def test_app_default_retry_policy(app):
+    # Test that app used module defaults
+    assert app.get_default_retry_policy() == kafkaesk.get_default_retry_policy()
+
+    # Test that the app's default retry policy can be updated
+    app.set_default_retry_policy(kafkaesk.retry.Forward)
+    assert app.get_default_retry_policy() == kafkaesk.retry.Forward
+    assert kafkaesk.get_default_retry_policy() == kafkaesk.retry.NoRetry
+
+    # Test that setting an app's default policy to none will use module default
+    app.set_default_retry_policy(None)
+    assert app.get_default_retry_policy() == kafkaesk.get_default_retry_policy()
+
+
 @pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_consumer_health_check():
     app = kafkaesk.Application()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -180,6 +180,7 @@ async def test_subscription_creates_default_retry_policy(app):
 
     factory_mock.assert_called_once()
     factory_mock.return_value.initialize.assert_awaited_once()
+    factory_mock.return_value.finalize.assert_awaited_once()
 
 
 @pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,205 @@
+from aiokafka.structs import ConsumerRecord
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import asyncio
+import kafkaesk
+import pydantic
+import pytest
+
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    AsyncMock = None
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def record():
+    return ConsumerRecord(
+        topic="foobar",
+        partition=0,
+        offset=0,
+        timestamp=1604951726856,
+        timestamp_type=0,
+        key=None,
+        value=b'{"schema":"Foo:1","data":{"bar":"1"}}',
+        checksum=None,
+        serialized_key_size=-1,
+        serialized_value_size=37,
+        headers=(),
+    )
+
+
+async def noop_callback(*args, **kwargs):
+    ...
+
+
+async def test_default_retry_policy():
+    # Check that the initial default is correct
+    assert kafkaesk.get_default_retry_policy() == kafkaesk.retry.NoRetry
+
+    # Check that the default policy can be changed
+    kafkaesk.set_default_retry_policy(kafkaesk.retry.Forward)
+    assert kafkaesk.get_default_retry_policy() == kafkaesk.retry.Forward
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
+async def test_retry_policy(app, record):
+    class NOOPRetry(kafkaesk.retry.RetryPolicy):
+        def __init__(self):
+            self._should_retry = True
+
+            super().__init__()
+
+        def set_should_retry(self, action):
+            self._should_retry = action
+
+        def should_retry(self, *args, **kwargs):
+            return self._should_retry
+
+        handle_retry = AsyncMock()
+        handle_failure = AsyncMock()
+
+    policy = NOOPRetry()
+    subscription = kafkaesk.app.Subscription("foobar", noop_callback, "group", policy)
+
+    error = kafkaesk.exceptions.UnhandledMessage()
+
+    # Check for initilization errors
+    with pytest.raises(RuntimeError):
+        await policy(record, error)
+
+    await policy.initialize(app, subscription)
+
+    # Check that retry logic is called
+    with patch("kafkaesk.retry.MESSAGE_REQUEUED") as requeued_metrics:
+        await policy(record, error)
+        policy.handle_retry.assert_called_once()
+
+        requeued_metrics.labels.assert_called_with(
+            stream_id="foobar", partition=0, group_id="group", error=error.__class__.__name__
+        )
+        requeued_metrics.labels(
+            stream_id="foobar", partition=0, group_id="group", error=error.__class__.__name__
+        ).inc.assert_called_once()
+
+    # Check that failure logic is called
+    with patch("kafkaesk.retry.MESSAGE_FAILED") as failed_metrics:
+        policy.set_should_retry(False)
+
+        await policy(record, error)
+        policy.handle_failure.assert_called_once()
+
+        failed_metrics.labels.assert_called_with(
+            stream_id="foobar", partition=0, group_id="group", error=error.__class__.__name__
+        )
+        failed_metrics.labels(
+            stream_id="foobar", partition=0, group_id="group", error=error.__class__.__name__
+        ).inc.assert_called_once()
+
+
+async def test_no_retry_policy(app, record):
+    policy = kafkaesk.retry.NoRetry()
+    subscription = kafkaesk.app.Subscription("foobar", noop_callback, "group", policy)
+
+    await policy.initialize(app, subscription)
+    error = kafkaesk.exceptions.UnhandledMessage()
+
+    assert policy.should_retry(record, error) is False
+    with pytest.raises(kafkaesk.exceptions.UnhandledMessage):
+        await policy.handle_failure(record, error)
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
+async def test_forward_retry_policy(record):
+    app_mock = AsyncMock()
+
+    policy = kafkaesk.retry.Forward()
+    subscription = kafkaesk.app.Subscription("foobar", noop_callback, "group", policy)
+
+    await policy.initialize(app_mock, subscription)
+    error = kafkaesk.exceptions.UnhandledMessage()
+
+    # Make sure we never retry
+    assert policy.should_retry(record, error) is False
+
+    # Check that failed messages are forwarded to the correct queue
+    await policy(record, error)
+
+    app_mock.publish.assert_awaited_once()
+    assert app_mock.publish.mock_calls[0].args[0] == "group__foobar"
+    assert isinstance(app_mock.publish.mock_calls[0].args[1], kafkaesk.retry.FailureMessage)
+
+
+async def test_subscribe_sets_default_retry_policy(app):
+    @app.schema("Foo", version=1)
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    @app.subscribe("foo.bar", group="test_group")
+    async def noop(data: Foo):
+        ...
+
+    assert app._subscriptions[0].retry_policy is None
+
+
+async def test_subscribe_sets_retry_policy(app):
+    @app.schema("Foo", version=1)
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    @app.subscribe("foo.bar", group="test_group", retry=kafkaesk.retry.NoRetry())
+    async def noop(data: Foo):
+        ...
+
+    assert isinstance(app._subscriptions[0].retry_policy, kafkaesk.retry.NoRetry)
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
+async def test_subscription_creates_default_retry_policy(app):
+    @app.schema("Foo", version=1)
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    @app.subscribe("foo.bar", group="test_group")
+    async def noop(data: Foo):
+        ...
+
+    factory_mock = Mock(return_value=AsyncMock())
+    app.set_default_retry_policy(factory_mock)
+
+    async with app:
+        fut = asyncio.create_task(app.consume_for(1, seconds=5))
+        await asyncio.sleep(0.2)
+
+        await app.publish("foo.bar", Foo(bar="1"))
+        await app.flush()
+        await fut
+
+    factory_mock.assert_called_once()
+    factory_mock.return_value.initialize.assert_awaited_once()
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
+async def test_subscription_calls_retry_policy(app):
+    policy_mock = AsyncMock()
+
+    @app.schema("Foo", version=1)
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    @app.subscribe("foo.bar", group="test_group", retry=policy_mock)
+    async def noop(data: Foo):
+        raise kafkaesk.exceptions.UnhandledMessage()
+
+    async with app:
+        fut = asyncio.create_task(app.consume_for(1, seconds=5))
+        await asyncio.sleep(0.2)
+
+        await app.publish("foo.bar", Foo(bar="1"))
+        await app.flush()
+        await fut
+
+    policy_mock.assert_awaited_once()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -81,7 +81,7 @@ async def test_retry_policy(app, record):
         def should_requeue(self, *args, **kwargs):
             return self._retry_flag
 
-        handle_retry = AsyncMock()
+        handle_requeue = AsyncMock()
         handle_failure = AsyncMock()
 
     policy = NOOPRetry()
@@ -98,7 +98,7 @@ async def test_retry_policy(app, record):
     # Check that retry logic is called
     with patch("kafkaesk.retry.MESSAGE_REQUEUED") as requeued_metrics:
         await policy(record, error)
-        policy.handle_retry.assert_called_once()
+        policy.handle_requeue.assert_called_once()
 
         requeued_metrics.labels.assert_called_with(
             stream_id="foobar", partition=0, group_id="group", error=error.__class__.__name__


### PR DESCRIPTION
Initial pass at introduction an interface for a Retry Policy and associated configuration.

# Retry Policy
A retry policy is a class that can make retry decisions about a message that was not processed successfully by a subscriber.  These retry policies implement the interface defined by `kafkaesk.retry.RetryPolicy`.

# Configuration
A client can specify a retry policy by passing in an instance of a `RetryPolicy` when registering a new subscriber.  If no policy is specified then the `Application` default policy will be used.  If the `Application` does not have a default policy then the global kafkaesk policy will be used

By default, the global kafkaesk retry policy is `NoRetry`.

# Policies
This PR initially only implements two very basic retry policies:

## NoRetry
This policy will not attempt to retry any messages nor will it forward messages to a failure topic.  Any exceptions received will be raised, mimicking the behavior we have today.

## Forward
This policy will not attempt to retry and messages and will forward those messages to a failure topic.  The topic's name will be based on the consumer's `group_id` and the `stream_id` the message was initially received on.