### PR TITLE
Retry Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class ContentMessage(BaseModel):
     foo: str
 
 
-@app.subscribe("content.*", "group_id", {Exception: kafkaesk.retry.Forward("dlx.content")})
+@app.subscribe("content.*", "group_id", retry_handlers={Exception: kafkaesk.retry.Forward("dlx.content")})
 async def get_messages(data: ContentMessage):
     raise Exception("UnhandledException")
 

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -261,7 +261,7 @@ class SubscriptionConsumer:
                         error=err.__class__.__name__,
                         group_id=self._subscription.group,
                     ).inc()
-                    await retry_policy(record=record, error=err)
+                    await retry_policy(record=record, exception=err)
                 finally:
                     context.span.finish()
                     context.close()

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -53,6 +53,7 @@ class Subscription:
         stream_id: str,
         func: Callable,
         group: str,
+        *,
         retry_handlers: Optional[Dict[Type[Exception], RetryHandler]] = None,
     ):
         self.stream_id = stream_id
@@ -314,6 +315,7 @@ class Router:
         self,
         stream_id: str,
         group: str,
+        *,
         retry_handlers: Optional[Dict[Type[Exception], RetryHandler]] = None,
     ) -> Callable:
         def inner(func: Callable) -> Callable:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -268,7 +268,10 @@ class SubscriptionConsumer:
                     await self.emit("message", record=record)
         finally:
             # Shutdown the retry policy
-            await retry_policy.finalize()
+            try:
+                await retry_policy.finalize()
+            except Exception:
+                logger.info("Cound not properly stop retry policy", exc_info=True)
             try:
                 await self._consumer.commit()
             except Exception:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -12,6 +12,8 @@ from .metrics import MESSAGE_LEAD_TIME
 from .metrics import NOERROR
 from .metrics import PRODUCER_TOPIC_OFFSET
 from .metrics import PUBLISHED_MESSAGES
+from .retry import RetryHandler
+from .retry import RetryPolicy
 from .utils import resolve_dotted_name
 from asyncio.futures import Future
 from functools import partial
@@ -46,10 +48,17 @@ logger = logging.getLogger("kafkaesk")
 
 
 class Subscription:
-    def __init__(self, stream_id: str, func: Callable, group: str):
+    def __init__(
+        self,
+        stream_id: str,
+        func: Callable,
+        group: str,
+        retry_handlers: Optional[Dict[Type[Exception], RetryHandler]] = None,
+    ):
         self.stream_id = stream_id
         self.func = func
         self.group = group
+        self.retry_handlers = retry_handlers
 
     def __repr__(self) -> str:
         return f"<Subscription stream: {self.stream_id} >"
@@ -162,6 +171,15 @@ class SubscriptionConsumer:
             self._consumer, self._app, self._subscription.group
         )
         self._consumer.subscribe(pattern=pattern, listener=listener)
+
+        # Initialize subscribers retry policy
+        retry_policy = RetryPolicy(
+            app=self._app,
+            subscription=self._subscription,
+            retry_handlers=self._subscription.retry_handlers,
+        )
+        await retry_policy.initialize()
+
         await self._consumer.start()
 
         msg_handler = _raw_msg_handler
@@ -236,22 +254,21 @@ class SubscriptionConsumer:
                         partition=record.partition,
                         group_id=self._subscription.group,
                     ).inc()
-                except UnhandledMessage:
-                    # how should we handle this? Right now, fail hard
-                    logger.warning(f"Could not process msg: {record}", exc_info=True)
-                    # We increase the error counter
+                except Exception as err:
                     CONSUMED_MESSAGES.labels(
                         stream_id=record.topic,
                         partition=record.partition,
-                        error="UnhandledMessage",
+                        error=err.__class__.__name__,
                         group_id=self._subscription.group,
                     ).inc()
-
+                    await retry_policy(record=record, error=err)
                 finally:
                     context.span.finish()
                     context.close()
                     await self.emit("message", record=record)
         finally:
+            # Shutdown the retry policy
+            await retry_policy.finalize()
             try:
                 await self._consumer.commit()
             except Exception:
@@ -290,9 +307,16 @@ class Router:
 
         self._event_handlers[name].append(handler)
 
-    def subscribe(self, stream_id: str, group: str,) -> Callable:
+    def subscribe(
+        self,
+        stream_id: str,
+        group: str,
+        retry_handlers: Optional[Dict[Type[Exception], RetryHandler]] = None,
+    ) -> Callable:
         def inner(func: Callable) -> Callable:
-            subscription = Subscription(stream_id, func, group or func.__name__)
+            subscription = Subscription(
+                stream_id, func, group or func.__name__, retry_handlers=retry_handlers
+            )
             self._subscriptions.append(subscription)
             return func
 

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -174,11 +174,7 @@ class SubscriptionConsumer:
         self._consumer.subscribe(pattern=pattern, listener=listener)
 
         # Initialize subscribers retry policy
-        retry_policy = RetryPolicy(
-            app=self._app,
-            subscription=self._subscription,
-            retry_handlers=self._subscription.retry_handlers,
-        )
+        retry_policy = RetryPolicy(app=self._app, subscription=self._subscription,)
         await retry_policy.initialize()
 
         await self._consumer.start()

--- a/kafkaesk/metrics.py
+++ b/kafkaesk/metrics.py
@@ -68,6 +68,12 @@ RETRY_HANDLER_DROP = client.Counter(
     ["stream_id", "group_id", "partition", "handler", "exception"],
 )
 
+RETRY_HANDLER_RAISE = client.Counter(
+    "kafkaesk_retry_handler_raise",
+    "Number of times the retry handler raised a message exception",
+    ["stream_id", "group_id", "partition", "handler", "exception"],
+)
+
 RETRY_CONSUMER_TOPIC_OFFSET = client.Gauge(
     "kafkaesk_retry_consumed_topic_offset",
     "Offset for consumed messages in a retry topic",

--- a/kafkaesk/metrics.py
+++ b/kafkaesk/metrics.py
@@ -42,3 +42,60 @@ MESSAGE_LEAD_TIME = client.Histogram(
 CONSUMER_REBALANCED = client.Counter(
     "kafkaesk_consumer_rebalanced", "Consumer rebalances", ["stream_id", "group_id", "partition"],
 )
+
+RETRY_POLICY = client.Counter(
+    "kafkaesk_retry_policy",
+    "Number of times the retry policy has been run",
+    ["stream_id", "group_id", "partition", "handler", "exception"],
+)
+
+
+RETRY_POLICY_TIME = client.Histogram(
+    "kafkaesk_retry_policy_time",
+    "Time taken for a RetryPolicy to process a message (in seconds)",
+    ["stream_id", "group_id", "partition"],
+)
+
+RETRY_HANDLER_FORWARD = client.Counter(
+    "kafkaesk_retry_handler_forward",
+    "Number of times a retry handler has forwarded a message to a new stream",
+    ["stream_id", "group_id", "partition", "handler", "exception", "forward_stream_id"],
+)
+
+RETRY_HANDLER_DROP = client.Counter(
+    "kafkaesk_retry_handler_drop",
+    "Number of times the retry handler dropped a message without forwarding it",
+    ["stream_id", "group_id", "partition", "handler", "exception"],
+)
+
+RETRY_CONSUMER_TOPIC_OFFSET = client.Gauge(
+    "kafkaesk_retry_consumed_topic_offset",
+    "Offset for consumed messages in a retry topic",
+    ["group_id", "partition", "stream_id", "handler", "retry_stream_id", "retry_stream_partition"],
+)
+
+RETRY_CONSUMER_MESSAGE_LEAD_TIME = client.Histogram(
+    "kafkaesk_retry_message_lead_time",
+    "Time that the message has been waiting to be handled by a retry consumer (in seconds)",
+    ["stream_id", "group_id", "partition", "handler", "retry_stream_id", "retry_stream_partition"],
+)
+
+RETRY_CONSUMER_CONSUMED_MESSAGE_TIME = client.Histogram(
+    "kafkaesk_retry_consumed_message_elapsed_time",
+    "Processing time for consumed retry message (in seconds)",
+    ["stream_id", "group_id", "partition", "handler", "retry_stream_id", "retry_stream_partition"],
+)
+
+RETRY_CONSUMER_CONSUMED_MESSAGES = client.Counter(
+    "kafkaesk_retry_consumed_messages",
+    "Number of consumed retry messages",
+    [
+        "stream_id",
+        "partition",
+        "error",
+        "group_id",
+        "handler",
+        "retry_stream_id",
+        "retry_stream_partition",
+    ],
+)

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -271,7 +271,7 @@ class RetryHandler(ABC):
         ).inc()
 
 
-class NoRetry(RetryHandler):
+class Drop(RetryHandler):
     async def __call__(
         self,
         policy: RetryPolicy,

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -26,7 +26,7 @@ class Record(BaseModel):
     timestamp: int
     timestamp_type: int
     key: Optional[str] = None
-    value: bytes
+    value: str
     checksum: Optional[int] = None
     serialized_key_size: int
     serialized_value_size: int
@@ -41,7 +41,7 @@ class Record(BaseModel):
             timestamp=record.timestamp,  # type: ignore
             timestamp_type=record.timestamp_type,  # type: ignore
             key=record.key,  # type: ignore
-            value=record.value,  # type: ignore
+            value=record.value.decode("utf-8"),  # type: ignore
             checksum=record.checksum,  # type: ignore
             serialized_key_size=record.serialized_key_size,  # type: ignore
             serialized_value_size=record.serialized_value_size,  # type: ignore
@@ -49,7 +49,11 @@ class Record(BaseModel):
         )
 
     def to_consumer_record(self) -> ConsumerRecord:
-        return ConsumerRecord(**self.dict())  # type: ignore
+        # We need to convert the value back into bytes before giving this back to the consumer
+        data = self.dict()
+        data["value"] = data["value"].encode("utf-8")
+
+        return ConsumerRecord(**data)  # type: ignore
 
 
 class FailureInfo(BaseModel):

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING is True:
     from .app import Subscription
 
 
+RETRY_HISTORY_FAILURES_MAX_SIZE = 10
+
+
 class Record(BaseModel):
     topic: str
     partition: int
@@ -132,6 +135,9 @@ class RetryPolicy:
                     timestamp=datetime.now(),
                 )
             )
+            # Enforce a maximum number of failures kept
+            if len(retry_history.failures) > RETRY_HISTORY_FAILURES_MAX_SIZE:
+                retry_history.failures = retry_history.failures[-RETRY_HISTORY_FAILURES_MAX_SIZE:]
 
             try:
                 await handler(self, handler_key, retry_history, record, exception)

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -1,0 +1,216 @@
+from abc import ABC
+from aiokafka.structs import ConsumerRecord
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TYPE_CHECKING
+
+import asyncio
+import logging
+
+if TYPE_CHECKING is True:
+    from .app import Application
+    from .app import Subscription
+
+logger = logging.getLogger("kafkaesk.retry")
+
+
+class Record(BaseModel):
+    topic: str
+    partition: int
+    offset: int
+    timestamp: int
+    timestamp_type: int
+    key: Optional[str] = None
+    value: bytes
+    checksum: Optional[int] = None
+    serialized_key_size: int
+    serialized_value_size: int
+    headers: tuple
+
+    @classmethod
+    def from_consumer_record(cls, record: ConsumerRecord) -> "Record":
+        return cls(
+            topic=record.topic,
+            partition=record.partition,
+            offset=record.offset,
+            timestamp=record.timestamp,  # type: ignore
+            timestamp_type=record.timestamp_type,  # type: ignore
+            key=record.key,  # type: ignore
+            value=record.value,  # type: ignore
+            checksum=record.checksum,  # type: ignore
+            serialized_key_size=record.serialized_key_size,  # type: ignore
+            serialized_value_size=record.serialized_value_size,  # type: ignore
+            headers=record.headers,
+        )
+
+    def to_consumer_record(self) -> ConsumerRecord:
+        return ConsumerRecord(**self.dict())  # type: ignore
+
+
+class FailureInfo(BaseModel):
+    error: str
+    handler_key: str
+    timestamp: datetime
+
+
+class RetryHistory(BaseModel):
+    failures: List[FailureInfo] = []
+
+
+class RetryMessage(BaseModel):
+    original_record: Record
+    retry_history: RetryHistory
+
+
+class RetryPolicy:
+    def __init__(
+        self,
+        app: "Application",
+        subscription: "Subscription",
+        retry_handlers: Optional[Dict[Type[Exception], "RetryHandler"]] = None,
+    ):
+        self.app = app
+        self.subscription = subscription
+
+        self._handlers = retry_handlers or {}
+        self._handler_cache: Dict[Type[Exception], Tuple[str, RetryHandler]] = {}
+
+        self._initialized = False
+
+        if "RetryMessage:1" not in self.app.schemas:
+            self.app.schema("RetryMessage", version=1)(RetryMessage)
+
+    async def add_retry_handler(self, error: Type[Exception], handler: "RetryHandler") -> None:
+        if error in self._handlers:
+            raise ValueError(f"{error} error handler is already set")
+
+        self._handlers[error] = handler
+
+        if self._initialized is True:
+            await self._handlers[error].initialize()
+
+        # Clear handler cache when handler is added
+        self._handler_cache = {}
+
+    async def remove_retry_handler(self, error: Type[Exception]) -> None:
+        if error in self._handlers:
+            handler = self._handlers[error]
+
+            del self._handlers[error]
+
+            # Clear handler cache when handler is removed
+            self._handler_cache = {}
+
+            await handler.finalize()
+
+    async def initialize(self) -> None:
+        await asyncio.gather(*[handler.initialize() for handler in self._handlers.values()])
+        self._initialized = True
+
+    async def finalize(self) -> None:
+        self._initialized = False
+        await asyncio.gather(*[handler.finalize() for handler in self._handlers.values()])
+
+    async def __call__(
+        self,
+        record: ConsumerRecord,
+        error: Exception,
+        retry_history: Optional[RetryHistory] = None,
+    ) -> None:
+        if self._initialized is not True:
+            raise RuntimeError("RetryPolicy is not initalized")
+
+        handler_key, handler = self._get_handler(error)
+
+        if handler is None or handler_key is None:
+            raise error from error
+
+        if retry_history is None:
+            retry_history = RetryHistory()
+
+        # Add information about this failure to the history
+        retry_history.failures.append(
+            FailureInfo(
+                error=error.__class__.__name__, handler_key=handler_key, timestamp=datetime.now()
+            )
+        )
+
+        await handler(self, handler_key, retry_history, record, error)
+
+    def _get_handler(self, error: Exception) -> Tuple[Optional[str], Optional["RetryHandler"]]:
+        error_type = error.__class__
+
+        handler_key, handler = self._handler_cache.get(error_type, (None, None))
+
+        if handler is None:
+            handler = self._handlers.get(error_type)
+            if handler is not None:
+                handler_key = error_type.__name__
+                self._handler_cache[error_type] = (handler_key, handler)
+
+        if handler is None:
+            for handler_error_type in self._handlers.keys():
+                if isinstance(error, handler_error_type):
+                    handler = self._handlers[handler_error_type]
+                    handler_key = handler_error_type.__name__
+                    self._handler_cache[error_type] = (handler_key, handler)
+                    break
+
+        return (handler_key, handler)
+
+
+class RetryHandler(ABC):
+    def __init__(self, stream_id: str) -> None:
+        self.stream_id = stream_id
+
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def finalize(self) -> None:
+        self._initialized = False
+
+    async def __call__(
+        self,
+        policy: RetryPolicy,
+        handler_key: str,
+        retry_history: RetryHistory,
+        record: ConsumerRecord,
+        error: Exception,
+    ) -> None:
+        raise NotImplementedError
+
+
+class NoRetry(RetryHandler):
+    async def __call__(
+        self,
+        policy: RetryPolicy,
+        handler_key: str,
+        retry_history: RetryHistory,
+        record: ConsumerRecord,
+        error: Exception,
+    ) -> None:
+        logger.info("NoRetry handler recieved exception, dropping message", exc_info=error)
+
+
+class Forward(RetryHandler):
+    async def __call__(
+        self,
+        policy: RetryPolicy,
+        handler_key: str,
+        retry_history: RetryHistory,
+        record: ConsumerRecord,
+        error: Exception,
+    ) -> None:
+        await policy.app.publish(
+            self.stream_id,
+            RetryMessage(
+                original_record=Record.from_consumer_record(record), retry_history=retry_history
+            ),
+        )

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -117,7 +117,7 @@ class RetryPolicy:
             await handler.finalize()
 
     async def initialize(self) -> None:
-        await asyncio.gather(*[handler.initialize() for handler in self._handlers.values()])
+        await asyncio.gather(*[handler.initialize(self) for handler in self._handlers.values()])
         self._ready = True
 
     async def finalize(self) -> None:
@@ -212,7 +212,7 @@ class RetryHandler(ABC):
 
         self._ready = False
 
-    async def initialize(self) -> None:
+    async def initialize(self, policy: RetryPolicy) -> None:
         self._ready = True
 
     async def finalize(self) -> None:

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -100,7 +100,7 @@ class RetryPolicy:
         self._handlers[exception] = handler
 
         if self._ready is True:
-            await self._handlers[exception].initialize()
+            await self._handlers[exception].initialize(self)
 
         # Clear handler cache when handler is added
         self._handler_cache = {}

--- a/kafkaesk/retry.py
+++ b/kafkaesk/retry.py
@@ -1,3 +1,7 @@
+from .metrics import RETRY_HANDLER_DROP
+from .metrics import RETRY_HANDLER_FORWARD
+from .metrics import RETRY_POLICY
+from .metrics import RETRY_POLICY_TIME
 from abc import ABC
 from aiokafka.structs import ConsumerRecord
 from datetime import datetime
@@ -129,24 +133,41 @@ class RetryPolicy:
         if self._initialized is not True:
             raise RuntimeError("RetryPolicy is not initalized")
 
-        handler_key, handler = self._get_handler(exception)
+        with RETRY_POLICY_TIME.labels(
+            stream_id=record.topic, partition=record.partition, group_id=self.subscription.group,
+        ).time():
+            handler_key, handler = self._get_handler(exception)
 
-        if handler is None or handler_key is None:
-            raise exception from exception
+            if handler is None or handler_key is None:
+                RETRY_POLICY.labels(
+                    stream_id=record.topic,
+                    partition=record.partition,
+                    group_id=self.subscription.group,
+                    handler=None,
+                    exception=exception.__class__.__name__,
+                ).inc()
+                raise exception from exception
 
-        if retry_history is None:
-            retry_history = RetryHistory()
+            if retry_history is None:
+                retry_history = RetryHistory()
 
-        # Add information about this failure to the history
-        retry_history.failures.append(
-            FailureInfo(
-                exception=exception.__class__.__name__,
-                handler_key=handler_key,
-                timestamp=datetime.now(),
+            # Add information about this failure to the history
+            retry_history.failures.append(
+                FailureInfo(
+                    exception=exception.__class__.__name__,
+                    handler_key=handler_key,
+                    timestamp=datetime.now(),
+                )
             )
-        )
 
-        await handler(self, handler_key, retry_history, record, exception)
+            await handler(self, handler_key, retry_history, record, exception)
+            RETRY_POLICY.labels(
+                stream_id=record.topic,
+                partition=record.partition,
+                group_id=self.subscription.group,
+                handler=handler.__class__.__name__,
+                exception=exception.__class__.__name__,
+            ).inc()
 
     def _get_handler(self, exception: Exception) -> Tuple[Optional[str], Optional["RetryHandler"]]:
         exception_type = exception.__class__
@@ -171,6 +192,21 @@ class RetryPolicy:
 
 
 class RetryHandler(ABC):
+    """Base class implementing common logic for RetryHandlers
+
+    All RetryHandler's should implement the following metrics:
+
+    * RETRY_HANDLER_FORWARD - Note: This is implemented by RetryHandler._forward_message
+    * RETRY_HANDLER_DROP - Note: this is implemented by RetryHandler._drop_message
+    * RETRY_CONSUMER_TOPIC_OFFSET
+    * RETRY_CONSUMER_MESSAGE_LEAD_TIME - Note: If a RetryHandler's consumer expects a delay,
+        this delay should be subtracted from the lead time
+    * RETRY_CONSUMER_CONSUMED_MESSAGE_TIME
+    * RETRY_CONSUMER_CONSUMED_MESSAGES
+
+    See `kafkaesk.metrics` for more information on each of these metrics
+    """
+
     def __init__(self, stream_id: str) -> None:
         self.stream_id = stream_id
 
@@ -192,6 +228,48 @@ class RetryHandler(ABC):
     ) -> None:
         raise NotImplementedError
 
+    async def _drop_message(
+        self,
+        policy: RetryPolicy,
+        retry_history: RetryHistory,
+        record: ConsumerRecord,
+        exception: Exception,
+    ) -> None:
+        logger.info(
+            f"{self.__class__.__name__} handler recieved exception, dropping message",
+            exc_info=exception,
+        )
+        RETRY_HANDLER_DROP.labels(
+            stream_id=record.topic,
+            partition=record.partition,
+            group_id=policy.subscription.group,
+            handler=self.__class__.__name__,
+            exception=exception.__class__.__name__,
+        ).inc()
+
+    async def _forward_message(
+        self,
+        policy: RetryPolicy,
+        retry_history: RetryHistory,
+        record: ConsumerRecord,
+        exception: Exception,
+        forward_stream_id: str,
+    ) -> None:
+        await policy.app.publish(
+            forward_stream_id,
+            RetryMessage(
+                original_record=Record.from_consumer_record(record), retry_history=retry_history
+            ),
+        )
+        RETRY_HANDLER_FORWARD.labels(
+            stream_id=record.topic,
+            partition=record.partition,
+            group_id=policy.subscription.group,
+            handler=self.__class__.__name__,
+            exception=exception.__class__.__name__,
+            forward_stream_id=forward_stream_id,
+        ).inc()
+
 
 class NoRetry(RetryHandler):
     async def __call__(
@@ -202,7 +280,7 @@ class NoRetry(RetryHandler):
         record: ConsumerRecord,
         exception: Exception,
     ) -> None:
-        logger.info("NoRetry handler recieved exception, dropping message", exc_info=exception)
+        await self._drop_message(policy, retry_history, record, exception)
 
 
 class Forward(RetryHandler):
@@ -214,9 +292,4 @@ class Forward(RetryHandler):
         record: ConsumerRecord,
         exception: Exception,
     ) -> None:
-        await policy.app.publish(
-            self.stream_id,
-            RetryMessage(
-                original_record=Record.from_consumer_record(record), retry_history=retry_history
-            ),
-        )
+        await self._forward_message(policy, retry_history, record, exception, self.stream_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.2.1"
+version = "0.3.0"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,6 +1,6 @@
 from aiokafka import ConsumerRecord
 from kafkaesk.kafka import KafkaTopicManager
-from kafkaesk.retry import NoRetry
+from kafkaesk.retry import Forward
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -125,7 +125,7 @@ async def test_multiple_subscribers_different_models(app):
     @app.subscribe(
         "foo.bar",
         group="test_group",
-        retry_handlers={Exception: NoRetry("test_group__foo.bar__Exception")},
+        retry_handlers={Exception: Forward("test_group__foo.bar__Exception")},
     )
     async def consume1(data: Foo1):
         consumed1.append(data)
@@ -133,7 +133,7 @@ async def test_multiple_subscribers_different_models(app):
     @app.subscribe(
         "foo.bar",
         group="test_group_2",
-        retry_handlers={Exception: NoRetry("test_group__foo.bar__Exception")},
+        retry_handlers={Exception: Forward("test_group__foo.bar__Exception")},
     )
     async def consume2(data: Foo2):
         consumed2.append(data)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -128,6 +128,7 @@ async def test_retry_policy(app: kafkaesk.Application, record: ConsumerRecord) -
     assert handler_mock.await_args[0][1] == "Exception"
 
 
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_retry_handler(record: ConsumerRecord) -> None:
     class NOOPHandler(retry.RetryHandler):
         ...

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,106 @@
+from aiokafka.structs import ConsumerRecord
+from datetime import datetime
+from kafkaesk import retry
+
+import kafkaesk
+import pytest
+
+try:
+    from unittest.mock import AsyncMock
+except:  # noqa
+    AsyncMock = None  # type: ignore
+
+pytestmark = pytest.mark.asyncio
+
+
+class NOOPException(Exception):
+    ...
+
+
+class NOOPCallback:
+    ...
+
+
+@pytest.fixture  # type: ignore
+def record() -> ConsumerRecord:
+    return ConsumerRecord(  # type: ignore
+        topic="foobar",
+        partition=0,
+        offset=0,
+        timestamp=1604951726856,
+        timestamp_type=0,
+        key=None,
+        value=b'{"schema":"Foo:1","data":{"bar":"1"}}',
+        checksum=None,
+        serialized_key_size=-1,
+        serialized_value_size=37,
+        headers=(),
+    )
+
+
+async def test_retry_message_is_serializable(record: ConsumerRecord) -> None:
+    retry_history = retry.RetryHistory()
+    retry_history.failures.append(
+        retry.FailureInfo(
+            error="UnhandledMessage", handler_key="Exception", timestamp=datetime.now()
+        )
+    )
+    retry_message = retry.RetryMessage(
+        original_record=retry.Record.from_consumer_record(record), retry_history=retry_history
+    )
+
+    json_serialized = retry_message.json()
+
+    # Ensure we can re-create a message from the json
+    retry.RetryMessage.parse_raw(json_serialized)
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
+async def test_retry_policy(app: kafkaesk.Application, record: ConsumerRecord) -> None:
+    policy = retry.RetryPolicy(app, kafkaesk.app.Subscription("foobar", NOOPCallback, "group"))
+    error = NOOPException()
+
+    # Check that policy errors if not initailized
+    with pytest.raises(RuntimeError):
+        await policy(record, error)
+
+    await policy.initialize()
+
+    # Check that un-configured exceptions are re-raised
+    with pytest.raises(NOOPException):
+        await policy(record, error)
+
+    # Check that configured exceptions are handled
+    handler_mock = AsyncMock()
+    await policy.add_retry_handler(NOOPException, handler_mock)
+    await policy(record, error)
+    handler_mock.assert_awaited_once()
+
+    # Check that configured exceptions can be removed
+    await policy.remove_retry_handler(NOOPException)
+    with pytest.raises(NOOPException):
+        await policy(record, error)
+
+    # Check that a configured exception handles inherited exceptions
+    handler_mock = AsyncMock()
+    await policy.add_retry_handler(Exception, handler_mock)
+    await policy(record, error)
+    handler_mock.assert_awaited_once()
+
+    # Check that the passed handler key matches the configured handler
+    # rather than the exception that was caught
+    assert handler_mock.await_args[0][1] == "Exception"
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
+async def test_forward_handler(record: ConsumerRecord) -> None:
+    policy = AsyncMock()
+    error = NOOPException()
+    retry_history = retry.RetryHistory()
+
+    forward = retry.Forward("test_stream")
+    await forward(policy, "NOOPException", retry_history, record, error)
+
+    policy.app.publish.assert_awaited_once()
+    assert policy.app.publish.await_args[0][0] == "test_stream"
+    assert isinstance(policy.app.publish.await_args[0][1], retry.RetryMessage)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -92,6 +92,14 @@ async def test_retry_policy(app: kafkaesk.Application, record: ConsumerRecord) -
     assert handler_mock.await_args[0][1] == "Exception"
 
 
+async def test_noretry_handler(record: ConsumerRecord) -> None:
+    error = NOOPException()
+    retry_history = retry.RetryHistory()
+
+    noretry = retry.NoRetry("Dummy")
+    await noretry(None, "NOOPException", retry_history, record, error)
+
+
 @pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_forward_handler(record: ConsumerRecord) -> None:
     policy = AsyncMock()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -173,12 +173,12 @@ async def test_retry_handler(record: ConsumerRecord) -> None:
 
 
 @pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
-async def test_noretry_handler(record: ConsumerRecord) -> None:
+async def test_drop_handler(record: ConsumerRecord) -> None:
     policy = AsyncMock()
     exception = NOOPException()
     retry_history = retry.RetryHistory()
 
-    noretry = retry.NoRetry("test_stream")
+    noretry = retry.Drop("test_stream")
     await noretry(policy, "NOOPException", retry_history, record, exception)
 
 


### PR DESCRIPTION
# Overview

This is the second attempt at introducing retries into `kafkaesk`.  This approach allows users to map exceptions to different handlers and updates the interface individual handlers must implement.

This attempt is based on feedback received on the original implementation, available here: #25 

# TODO

- [x] Add additional logging
- [x] Add metrics

# Configuration

When defining a `kafkaesk` subscriber, the user may optionally supply a dictionary mapping `Exception` types to `RetryHandler` instances.  If the subscriber raises one of those handled exceptions (or a sub-class of that exception), then the error will be handed off to the `RetryHandler`.  If not matching handler is found, the exception will be re-raised.

# RetryPolicy

The retry policy acts as a router between the `kafkaesk.app.ConsumerSubscriber` and the individual `RetryHandler` instances.  `RetryHandler`s may be registered to the `RetryPolicy` and will be searched through when `RetryPolicy()` is called.

# RetryHistory

The `RetryHistory` class represents all errors that have been encountered by subscribers while processing this message.  A `RetryHandler` can inspect these errors to decide if a retry should be attempted or if a backoff should be applied.

# HandlerKey

The `handler_key` attribute is passed from the `RetryPolicy` when calling a `RetryHandler`.  This represents the actual exception type matched when routing the message to a given `RetryHandler`.  This exception type may not be an exact match for the exception raised, as the raised exception may be a sub-type of the configured exception.  This allows the `RetryHandler` to make decisions about how to process the message.

# RetryHandler

A `RetryHandler` is an implementation of a particular retry strategy.  If any additional subscribers need to be created to implement retries, they should directly belong to the `RetryHandler` instance.

# RetryMessage

The `RetryMessage` is a wrapper around the original message retrieved from the stream and the `RetryHistory` for that message.  All `RetryHandler`s should wrap any messages they publish in this class to ensure the message history is available when the message is re-processed.

# Additional Retry Types
Once this approach is approved, there will be additional, more complex `RetryHandler`s implemented.  This initial implementation does not actually ever retry a message; the messages are either ignored (`Drop`) or sent to a queue with no consumer (`Forward`)

## Retry
## Retry With Delay / Backoff
