### PR TITLE
Implement auto commit strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     steps:
       - name: Checkout the repository
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Optional consumer injected parameters:
 
 - schema: str
 - record: aiokafka.structs.ConsumerRecord
+- app: kafkaesk.app.Application
+- subscriber: kafkaesk.app.SubscriptionConsumer
 
 Depending on the type annotation for the first parameter, you will get different data injected:
 
@@ -119,6 +121,20 @@ Depending on the type annotation for the first parameter, you will get different
 - `async def get_messages(data: bytes)`: give raw byte data
 - `async def get_messages(record: aiokafka.structs.ConsumerRecord)`: give kafka record object
 - `async def get_messages(data)`: raw json data in message
+
+
+## manual commit
+
+To accomplish a manual commit strategy yourself:
+
+```
+app = kafkaesk.Application(auto_commit=False)
+
+@app.subscribe('content.*')
+async def get_messages(data: ContentMessage, subscriber):
+    print(f"{data.foo}")
+    await subscriber.commit()
+```
 
 
 ## kafkaesk contract
@@ -183,6 +199,9 @@ Options:
 - topic_prefix: Optional[str]: topic name prefix to subscribe to
 - kafka_settings: Optional[Dict[str, Any]]: additional aiokafka settings to pass in
 - replication_factor: Optional[int]: what replication factor topics should be created with. Defaults to min(number of servers, 3).
+- kafka_api_version: str: default `auto`
+- auto_commit: bool: default `True`
+- auto_commit_interval_ms: int: default `5000`
 
 ## Dev
 
@@ -212,13 +231,6 @@ This extensions ships with two handlers capable of handling `kafkaesk.ext.loggin
 The stream handler is a very small wrapper around `logging.StreamHandler`, the signature is the same, the only difference is that the handler will attempt to convert any pydantic models it receives to a human readable log message.
 
 The kafkaesk handler has a few more bits going on in the background.  The handler has two required inputs, a `kafkaesk.app.Application` instance and a stream name.  Once initialized any logs emitted by the handler will be saved into an internal queue.  There is a worker task that handles pulling logs from the queue and writing those logs to the specified topic.
-
-# TODO
-
-(or a todo here)
-
-- [ ] be able to handle manual commit use-case
-- [ ] be able to reject commit/abort message handling
 
 # Naming things
 

--- a/kafkaesk/__init__.py
+++ b/kafkaesk/__init__.py
@@ -2,5 +2,7 @@ from .app import Application  # noqa
 from .app import Router  # noqa
 from .app import run  # noqa
 from .app import run_app  # noqa
+from .app import Subscription  # noqa
+from .app import SubscriptionConsumer  # noqa
 
 __version__ = "0.2.1"

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -450,7 +450,7 @@ class Application(Router):
         replication_factor: Optional[int] = None,
         kafka_api_version: str = "auto",
         auto_commit: bool = True,
-        auto_commit_interval_ms: int = 5000,
+        auto_commit_interval_ms: int = 3000,
     ):
         super().__init__()
         self._kafka_servers = kafka_servers

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -646,17 +646,6 @@ class CustomConsumerRebalanceListener(aiokafka.ConsumerRebalanceListener):
                 # and it's unclear if this is always right decision
                 await self.consumer.seek_to_beginning(tp)
 
-            # go back one message since we have auto_commit = true
-            # try:
-            #     position = await self.consumer.position(tp)
-            #     offset = position - 1
-            # except aiokafka.errors.IllegalStateError:
-            #     offset = -1
-            # if offset > 0:
-            #     self.consumer.seek(tp, offset)
-            # else:
-            #     await self.consumer.seek_to_beginning(tp)
-
 
 cli_parser = argparse.ArgumentParser(description="Run kafkaesk worker.")
 cli_parser.add_argument("app", help="Application object")

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -267,7 +267,7 @@ class SubscriptionConsumer:
             # Move the offset one position back so the failed message will be
             # reprocessed.
             tp = aiokafka.TopicPartition(record.topic, record.partition)
-            pos = await self._consumer.position(tp)
+            pos = self._consumer._subscription._assigned_state(tp).position
             self._consumer.seek(tp, pos - 1)
             raise exc
         finally:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -267,7 +267,7 @@ class SubscriptionConsumer:
             # Move the offset one position back so the failed message will be
             # reprocessed.
             tp = aiokafka.TopicPartition(record.topic, record.partition)
-            pos = self._consumer._subscription._assigned_state(tp).position
+            pos = self._consumer._subscription._assigned_state(tp).position  # type: ignore
             self._consumer.seek(tp, pos - 1)
             raise exc
         finally:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -450,7 +450,7 @@ class Application(Router):
         replication_factor: Optional[int] = None,
         kafka_api_version: str = "auto",
         auto_commit: bool = True,
-        auto_commit_interval_ms: int = 3000,
+        auto_commit_interval_ms: int = 2000,
     ):
         super().__init__()
         self._kafka_servers = kafka_servers

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -270,10 +270,6 @@ class SubscriptionConsumer:
             except Exception:
                 logger.info("Cound not properly stop retry policy", exc_info=True)
             try:
-                await self._consumer.commit()
-            except Exception:
-                logger.info("Could not commit current offsets", exc_info=True)
-            try:
                 await self._consumer.stop()
             except Exception:
                 logger.warning("Could not properly stop consumer", exc_info=True)

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -261,7 +261,6 @@ class SubscriptionConsumer:
                     ).inc()
                     await retry_policy(record=record, exception=err)
                 finally:
-                    context.span.finish()
                     context.close()
                     await self.emit("message", record=record)
         except Exception as exc:

--- a/kafkaesk/exceptions.py
+++ b/kafkaesk/exceptions.py
@@ -47,3 +47,7 @@ class ConsumerUnhealthyException(Exception):
     def __init__(self, subscriber_consumer: SubscriptionConsumer, reason: str):
         self.subscriber_consumer = subscriber_consumer
         self.reason = reason
+
+
+class AutoCommitError(ConsumerUnhealthyException):
+    ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,7 +80,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.6.20"
+version = "2020.11.8"
 
 [[package]]
 category = "dev"
@@ -352,7 +352,7 @@ description = "Utility library for gitignore style pattern matching of file path
 name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 category = "dev"
@@ -618,7 +618,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.10.28"
+version = "2020.11.13"
 
 [[package]]
 category = "dev"
@@ -626,13 +626,13 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.24.0"
+version = "2.25.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
@@ -684,7 +684,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.11"
+version = "1.26.2"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -733,6 +733,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 
 [metadata]
 content-hash = "06d133687b3398c32aefbac617627d63ead6300652c4867518ad82e6e1d3904c"
+lock-version = "1.0"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -760,8 +761,8 @@ black = [
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -773,6 +774,7 @@ click = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
@@ -910,8 +912,8 @@ parso = [
     {file = "parso-0.7.1.tar.gz", hash = "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
-    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pdbpp = [
     {file = "pdbpp-0.10.2.tar.gz", hash = "sha256:73ff220d5006e0ecdc3e2705d8328d8aa5ac27fef95cc06f6e42cd7d22d55eb8"},
@@ -1020,53 +1022,51 @@ pywin32 = [
     {file = "pywin32-227-cp39-cp39-win_amd64.whl", hash = "sha256:f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c"},
 ]
 regex = [
-    {file = "regex-2020.10.28-cp27-cp27m-win32.whl", hash = "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504"},
-    {file = "regex-2020.10.28-cp27-cp27m-win_amd64.whl", hash = "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e"},
-    {file = "regex-2020.10.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c454ad88e56e80e44f824ef8366bb7e4c3def12999151fd5c0ea76a18fe9aa3e"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:de7fd57765398d141949946c84f3590a68cf5887dac3fc52388df0639b01eda4"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:9b6305295b6591e45f069d3553c54d50cc47629eb5c218aac99e0f7fafbf90a1"},
-    {file = "regex-2020.10.28-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:bd904c0dec29bbd0769887a816657491721d5f545c29e30fd9d7a1a275dc80ab"},
-    {file = "regex-2020.10.28-cp36-cp36m-win32.whl", hash = "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582"},
-    {file = "regex-2020.10.28-cp36-cp36m-win_amd64.whl", hash = "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c"},
-    {file = "regex-2020.10.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:297116e79074ec2a2f885d22db00ce6e88b15f75162c5e8b38f66ea734e73c64"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:96f99219dddb33e235a37283306834700b63170d7bb2a1ee17e41c6d589c8eb9"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:227a8d2e5282c2b8346e7f68aa759e0331a0b4a890b55a5cfbb28bd0261b84c0"},
-    {file = "regex-2020.10.28-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:2564def9ce0710d510b1fc7e5178ce2d20f75571f788b5197b3c8134c366f50c"},
-    {file = "regex-2020.10.28-cp37-cp37m-win32.whl", hash = "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0"},
-    {file = "regex-2020.10.28-cp37-cp37m-win_amd64.whl", hash = "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a"},
-    {file = "regex-2020.10.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf4f896c42c63d1f22039ad57de2644c72587756c0cfb3cc3b7530cfe228277f"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux1_i686.whl", hash = "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b45bab9f224de276b7bc916f6306b86283f6aa8afe7ed4133423efb42015a898"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:52e83a5f28acd621ba8e71c2b816f6541af7144b69cc5859d17da76c436a5427"},
-    {file = "regex-2020.10.28-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:aacc8623ffe7999a97935eeabbd24b1ae701d08ea8f874a6ff050e93c3e658cf"},
-    {file = "regex-2020.10.28-cp38-cp38-win32.whl", hash = "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f"},
-    {file = "regex-2020.10.28-cp38-cp38-win_amd64.whl", hash = "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de"},
-    {file = "regex-2020.10.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:127a9e0c0d91af572fbb9e56d00a504dbd4c65e574ddda3d45b55722462210de"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:3dfca201fa6b326239e1bccb00b915e058707028809b8ecc0cf6819ad233a740"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:b8a686a6c98872007aa41fdbb2e86dc03b287d951ff4a7f1da77fb7f14113e4d"},
-    {file = "regex-2020.10.28-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c32c91a0f1ac779cbd73e62430de3d3502bbc45ffe5bb6c376015acfa848144b"},
-    {file = "regex-2020.10.28-cp39-cp39-win32.whl", hash = "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0"},
-    {file = "regex-2020.10.28-cp39-cp39-win_amd64.whl", hash = "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e"},
-    {file = "regex-2020.10.28.tar.gz", hash = "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b"},
+    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
+    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
+    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
+    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
+    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
+    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
+    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
+    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
+    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
+    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
+    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
+    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
+    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
 requests = [
-    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
-    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -1128,8 +1128,8 @@ ujson = [
     {file = "ujson-4.0.1.tar.gz", hash = "sha256:26cf6241b36ff5ce4539ae687b6b02673109c5e3efc96148806a7873eaa229d3"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
-    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
+    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
+    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/stubs/aiokafka/__init__.py
+++ b/stubs/aiokafka/__init__.py
@@ -62,6 +62,9 @@ class AIOKafkaConsumer:
     ):
         ...
 
+    async def getone(self, *partitions: Optional[List[TopicPartition]]) -> ConsumerRecord:
+        ...
+
     async def subscribe(
         self, pattern: Optional[str] = None, listener: Optional["ConsumerRebalanceListener"] = None
     ) -> None:

--- a/stubs/aiokafka/__init__.py
+++ b/stubs/aiokafka/__init__.py
@@ -4,8 +4,10 @@ from kafka.structs import TopicPartition
 from typing import Any
 from typing import AsyncIterator
 from typing import Awaitable
+from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 
 
@@ -76,7 +78,7 @@ class AIOKafkaConsumer:
     async def stop(self) -> None:
         ...
 
-    async def commit(self) -> None:
+    async def commit(self, to_commit: Optional[Dict[TopicPartition, int]] = None) -> None:
         ...
 
     def __aiter__(self) -> AsyncIterator[ConsumerRecord]:
@@ -92,6 +94,9 @@ class AIOKafkaConsumer:
         ...
 
     async def seek_to_beginning(self, tp: TopicPartition) -> None:
+        ...
+
+    def assignment(self) -> Set[TopicPartition]:
         ...
 
 

--- a/stubs/aiokafka/errors.py
+++ b/stubs/aiokafka/errors.py
@@ -6,6 +6,10 @@ class RequestTimedOutError(Exception):
     ...
 
 
+class ConsumerStoppedError(Exception):
+    ...
+
+
 class IllegalStateError(Exception):
     ...
 

--- a/stubs/kafka/errors.py
+++ b/stubs/kafka/errors.py
@@ -1,2 +1,10 @@
 class TopicAlreadyExistsError(Exception):
     ...
+
+
+class CommitFailedError(Exception):
+    ...
+
+
+class IllegalStateError(Exception):
+    ...

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,7 +55,6 @@ def test_mount_router(app):
     assert app.event_handlers == router.event_handlers
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_consumer_health_check():
     app = kafkaesk.Application()
     subscription_consumer = AsyncMock()
@@ -64,7 +63,6 @@ async def test_consumer_health_check():
     await app.health_check()
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_consumer_health_check_raises_exception():
     app = kafkaesk.Application()
     subscription_consumer = kafkaesk.SubscriptionConsumer(
@@ -77,7 +75,6 @@ async def test_consumer_health_check_raises_exception():
         await app.health_check()
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_consumer_health_check_raises_exception_if_commit_task_done():
     app = kafkaesk.Application()
     subscription_consumer = kafkaesk.SubscriptionConsumer(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,8 +65,11 @@ async def test_consumer_health_check():
 @pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_consumer_health_check_raises_exception():
     app = kafkaesk.Application()
-    subscription_consumer = AsyncMock()
+    subscription_consumer = kafkaesk.SubscriptionConsumer(
+        app, kafkaesk.Subscription("foo", lambda: 1, "group")
+    )
     app._subscription_consumers.append(subscription_consumer)
-    subscription_consumer.consumer._client.ready.return_value = False
+    subscription_consumer._consumer = AsyncMock()
+    subscription_consumer._consumer._client.ready.return_value = False
     with pytest.raises(kafkaesk.exceptions.ConsumerUnhealthyException):
         await app.health_check()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,8 @@ except ImportError:
     AsyncMock = None
 
 
+from unittest.mock import MagicMock
+
 import kafkaesk
 import kafkaesk.exceptions
 import pydantic
@@ -72,4 +74,18 @@ async def test_consumer_health_check_raises_exception():
     subscription_consumer._consumer = AsyncMock()
     subscription_consumer._consumer._client.ready.return_value = False
     with pytest.raises(kafkaesk.exceptions.ConsumerUnhealthyException):
+        await app.health_check()
+
+
+@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
+async def test_consumer_health_check_raises_exception_if_commit_task_done():
+    app = kafkaesk.Application()
+    subscription_consumer = kafkaesk.SubscriptionConsumer(
+        app, kafkaesk.Subscription("foo", lambda: 1, "group")
+    )
+    subscription_consumer._consumer = MagicMock()
+    subscription_consumer._auto_commit_task = MagicMock()
+    subscription_consumer._auto_commit_task.done.return_value = True
+    app._subscription_consumers.append(subscription_consumer)
+    with pytest.raises(kafkaesk.exceptions.AutoCommitError):
         await app.health_check()

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -242,7 +242,6 @@ async def test_cache_topic_exists_topic_mng(kafka):
     assert await mng.topic_exists(topic_id)
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_subscription_creates_retry_policy(app):
     @app.schema("Foo", version=1)
     class Foo(pydantic.BaseModel):
@@ -268,7 +267,6 @@ async def test_subscription_creates_retry_policy(app):
         policy_mock.return_value.finalize.assert_awaited_once()
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")
 async def test_subscription_calls_retry_policy(app):
     handler_mock = AsyncMock()
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -333,7 +333,6 @@ async def test_subscription_failure(app):
 
         await fut
 
-    # We still missing one message, we need to set the offset to `pos-1` when init the consumer
     probe.assert_has_calls(
         [call("error", Foo(bar="1")), call("ok", Foo(bar="1")), call("ok", Foo(bar="2"))],
         any_order=True,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -59,7 +59,6 @@ async def test_retry_message_is_serializable(record: ConsumerRecord) -> None:
     deserialized_message.original_record.to_consumer_record()
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_retry_policy(app: kafkaesk.Application, record: ConsumerRecord) -> None:
     policy = retry.RetryPolicy(app, kafkaesk.app.Subscription("foobar", NOOPCallback, "group"))
     exception = NOOPException()
@@ -169,7 +168,6 @@ async def test_retry_policy_default_handler(app: kafkaesk.Application) -> None:
     assert isinstance(handler, retry.Raise)
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_retry_handler(record: ConsumerRecord) -> None:
     class NOOPHandler(retry.RetryHandler):
         ...
@@ -227,7 +225,6 @@ async def test_retry_handler(record: ConsumerRecord) -> None:
         policy.app.publish.assert_awaited_once()
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_raise_handler(record: ConsumerRecord) -> None:
     policy = AsyncMock()
     exception = NOOPException()
@@ -238,7 +235,6 @@ async def test_raise_handler(record: ConsumerRecord) -> None:
         await raise_handler(policy, "Exception", retry_history, record, exception)
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_drop_handler(record: ConsumerRecord) -> None:
     policy = AsyncMock()
     exception = NOOPException()
@@ -248,7 +244,6 @@ async def test_drop_handler(record: ConsumerRecord) -> None:
     await noretry(policy, "NOOPException", retry_history, record, exception)
 
 
-@pytest.mark.skipif(AsyncMock is None, reason="Only py 3.8")  # type: ignore
 async def test_forward_handler(record: ConsumerRecord) -> None:
     policy = AsyncMock()
     exception = NOOPException()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
+from kafkaesk.exceptions import SchemaConflictException
+
 import pydantic
 import pytest
-from kafkaesk.exceptions import SchemaConflictException
 
 pytestmark = pytest.mark.asyncio
 
@@ -15,3 +16,26 @@ async def test_not_allowed_to_register_same_schema_twice(app):
         @app.schema("Foo", version=1)
         class Foo2(pydantic.BaseModel):
             foo: str
+
+
+async def test_do_not_require_schema_name(app):
+    @app.schema()
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    assert "Foo:1" in app._schemas
+
+
+async def test_get_registered_schema(app):
+    @app.schema()
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    assert app.get_schema_reg(Foo) is not None
+
+
+async def test_get_registered_schema_missing(app):
+    class Foo(pydantic.BaseModel):
+        bar: str
+
+    assert app.get_schema_reg(Foo) is None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,6 @@
 import pydantic
 import pytest
-from kafkaesk.exceptions import (
-    SchemaConflictException
-)
+from kafkaesk.exceptions import SchemaConflictException
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,0 +1,149 @@
+from aiokafka.structs import TopicPartition
+from kafkaesk import Application
+from kafkaesk import Subscription
+from kafkaesk import SubscriptionConsumer
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+
+import aiokafka.errors
+import asyncio
+import kafka.errors
+import logging
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def subscription():
+    yield SubscriptionConsumer(Application(), Subscription("foo", lambda: 1, "group"))
+
+
+async def test_consumer_property_rasises_exception(subscription):
+    with pytest.raises(RuntimeError):
+        subscription.consumer
+
+
+async def test_lifecycle_logs_broken_version(subscription, caplog):
+    subscription._run = AsyncMock(side_effect=aiokafka.errors.UnrecognizedBrokerVersion)
+    await subscription()
+    assert subscription._auto_commit_task is not None
+    await asyncio.sleep(0.01)  # let it cancel
+    assert subscription._auto_commit_task.done()
+
+    assert "Could not determine kafka version." in caplog.records[-1].message
+
+
+async def test_lifecycle_logs_connection_error(subscription, caplog):
+    subscription._run = AsyncMock(side_effect=aiokafka.errors.KafkaConnectionError)
+    await subscription()
+    assert subscription._auto_commit_task is not None
+    await asyncio.sleep(0.01)  # let it cancel
+    assert subscription._auto_commit_task.done()
+
+    assert "Connection error" in caplog.records[-1].message
+
+
+async def test_lifecycle_logs_exits(subscription, caplog):
+    caplog.set_level(logging.DEBUG)
+    subscription._run = AsyncMock(side_effect=RuntimeError)
+    await subscription()
+    assert subscription._auto_commit_task is not None
+    await asyncio.sleep(0.01)  # let it cancel
+    assert subscription._auto_commit_task.done()
+
+    assert "Consumer stopped" in caplog.records[-1].message
+
+
+async def test_commit(subscription):
+    subscription._consumer = AsyncMock()
+    subscription._consumer.assignment = MagicMock(return_value=[TopicPartition("topic", 1)])
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 1
+
+    subscription.record_commit(record)
+
+    await subscription.commit()
+    assert len(subscription._to_commit) == 0
+
+    subscription.consumer.commit.assert_called_with({TopicPartition("topic", 1): 2})
+
+
+async def test_do_not_commit_when_assignment_changed(subscription):
+    subscription._consumer = AsyncMock()
+    subscription._consumer.assignment = MagicMock(return_value=[TopicPartition("topic", 2)])
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 1
+
+    subscription.record_commit(record)
+
+    await subscription.commit()
+
+    subscription.consumer.commit.assert_not_called()
+
+
+async def test_commit_failed_keeps_record(subscription):
+    subscription._consumer = AsyncMock()
+    subscription._consumer.assignment = MagicMock(return_value=[TopicPartition("topic", 1)])
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 1
+
+    subscription.record_commit(record)
+
+    subscription.consumer.commit.side_effect = kafka.errors.CommitFailedError
+    await subscription.commit()
+
+    assert subscription._to_commit == {TopicPartition("topic", 1): 2}
+
+
+async def test_commit_failed_handles_new_records(subscription):
+    subscription._consumer = AsyncMock()
+    subscription._consumer.assignment = MagicMock(return_value=[TopicPartition("topic", 1)])
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 1
+
+    subscription.record_commit(record)
+
+    async def delayed_commit(*args):
+        await asyncio.sleep(0.01)
+        raise kafka.errors.CommitFailedError
+
+    subscription.consumer.commit = delayed_commit
+    task = asyncio.create_task(subscription.commit())
+    await asyncio.sleep(0.005)
+    # now, record new message
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 2
+
+    subscription.record_commit(record)
+
+    await task
+
+    assert subscription._to_commit == {TopicPartition("topic", 1): 3}
+
+
+async def test_commit_drop_when_rebalance(subscription):
+    subscription._consumer = AsyncMock()
+    subscription._consumer.assignment = MagicMock(return_value=[TopicPartition("topic", 1)])
+    record = Mock()
+    record.topic = "topic"
+    record.partition = 1
+    record.offset = 1
+
+    subscription.record_commit(record)
+
+    subscription.consumer.commit.side_effect = kafka.errors.IllegalStateError
+    await subscription.commit()
+
+    assert len(subscription._to_commit) == 0


### PR DESCRIPTION

## Problem
aiokafka will still commit messages that had errors.


## Solution
Provide our own auto commit strategy that will take errors into account and not commit error'd messages.

## Extras
- fix to not close the jaeger span twice.
- do not require schema to be registered in order to publish
- provide `raw_publish` method to be able to publish bytes data directly instead of pydantic model