### PR TITLE
Add check for unconfigured app at initialization

### DIFF
--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -1,3 +1,4 @@
+from .exceptions import AppNotConfiguredException
 from .exceptions import ProducerUnhealthyException
 from .exceptions import SchemaConflictException
 from .exceptions import StopConsumer
@@ -264,6 +265,10 @@ class Application(Router):
         if replication_factor is not None:
             self._replication_factor = replication_factor
 
+    @property
+    def is_configured(self) -> bool:
+        return bool(self._kafka_servers)
+
     async def publish_and_wait(
         self,
         stream_id: str,
@@ -393,6 +398,9 @@ class Application(Router):
         return self._producer
 
     async def initialize(self) -> None:
+        if not self.is_configured:
+            raise AppNotConfiguredException
+
         await self._call_event_handlers("initialize")
 
         for reg in self._schemas.values():

--- a/kafkaesk/exceptions.py
+++ b/kafkaesk/exceptions.py
@@ -46,3 +46,7 @@ class AutoCommitError(ConsumerUnhealthyException):
 class ProducerUnhealthyException(Exception):
     def __init__(self, producer: aiokafka.AIOKafkaProducer):
         self.producer = producer
+
+
+class AppNotConfiguredException(Exception):
+    ...

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -206,6 +206,11 @@ class TestApplication:
         assert app._kafka_api_version == "api_version"
         assert app._replication_factor == "replication_factor"
 
+    async def test_initialize_with_unconfigured_app_raises_exception(self):
+        app = kafkaesk.Application()
+        with pytest.raises(kafkaesk.exceptions.AppNotConfiguredException):
+            await app.initialize()
+
     async def test_publish_propagates_headers(self):
         app = kafkaesk.Application(kafka_servers=["foo"])
 


### PR DESCRIPTION
## Proposed Changes

  - As it is possible by design to instantiate the app without kafka servers, add an Exception raise in the initialization, so the app does not error out further along the road.