### PR TITLE
Increase pydantic log size

### DIFF
--- a/kafkaesk/ext/logging/handler.py
+++ b/kafkaesk/ext/logging/handler.py
@@ -55,7 +55,8 @@ class PydanticStreamHandler(logging.StreamHandler):
                 formatted = f"{field_name}={val}"
                 size += len(formatted)
                 formatted_data.append(formatted)
-                if size > 50:
+
+                if size > 256:
                     break
             message += f": {', '.join(formatted_data)}"
             break

--- a/tests/acceptance/ext/logging/test_handler.py
+++ b/tests/acceptance/ext/logging/test_handler.py
@@ -100,13 +100,13 @@ class TestPydanticStreamHandler:
             foo: str
             bar: str
 
-        logger.info("Test Message %s", "extra", LogModel(foo="X" * 50, bar="Y" * 50))
+        logger.info("Test Message %s", "extra", LogModel(foo="X" * 256, bar="Y" * 256))
 
         message = stream_handler.getvalue()
 
         assert "Test Message extra" in message
-        assert f"foo={'X' * 50}" in message
-        assert f"bar={'Y' * 50}" not in message
+        assert f"foo={'X' * 256}" in message
+        assert f"bar={'Y' * 256}" not in message
 
 
 class TestPydanticKafkaeskHandler:


### PR DESCRIPTION
The current log size is potentially too short and results in Pydantic fields past the second one to be silently dropped from the log. 

Proposing a max log length of 256 to allow for a few more fields to be logged.