### PR TITLE
no timeout by default

### DIFF
--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -138,7 +138,7 @@ class Router:
         stream_id: str,
         group: str,
         *,
-        timeout_seconds: float = 5,
+        timeout_seconds: float = None,
         concurrency: int = None,
     ) -> Callable:
         def inner(func: Callable) -> Callable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.6.0"
+version = "0.6.1"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [


### PR DESCRIPTION
To keep compatibility with <0.6.0 behavior is better to define the default timeout as "no timeout"