### PR TITLE
Better error messages

### DIFF
--- a/examples/parallel.py
+++ b/examples/parallel.py
@@ -13,12 +13,7 @@ logging.basicConfig(level=logging.INFO)
 app = Application()
 
 
-@app.schema("Foobar",
-            streams=[
-                "content.foo",
-                "slow.content.foo",
-                "failed.content.foo"
-            ])
+@app.schema("Foobar", streams=["content.foo", "slow.content.foo", "failed.content.foo"])
 class Foobar(BaseModel):
     timeout: int
 
@@ -50,16 +45,14 @@ async def run():
     task = asyncio.create_task(generate_data(app))
 
     # Regular tasks should be consumed in less than 5s
-    app.subscribe("content.*",
-                  group="example_content_group",
-                  concurrency=10,
-                  timeout_seconds=5)(consumer_logic)
+    app.subscribe("content.*", group="example_content_group", concurrency=10, timeout_seconds=5)(
+        consumer_logic
+    )
 
     # Timeout taks (slow) can be consumed independendly, with different configuration and logic
-    app.subscribe("slow.content.*",
-                  group="timeout_example_content_group",
-                  concurrency=1,
-                  timeout_seconds=None)(consumer_logic)
+    app.subscribe(
+        "slow.content.*", group="timeout_example_content_group", concurrency=1, timeout_seconds=None
+    )(consumer_logic)
 
     await run_app(app)
 

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -569,6 +569,8 @@ async def run_app(app: Application) -> None:
             loop.add_signal_handler(getattr(signal, signame), partial(_sig_handler, app))
         done, pending = await fut
         logger.debug("Exiting consumer")
+
+        await app.stop()
         # re-raise any errors so we can validate during tests
         for task in done:
             exc = task.exception()

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -496,7 +496,7 @@ class Application(Router):
         await self.stop()
 
         # re-raise any errors so we can validate during tests
-        for task in done | pending:
+        for task in (done + pending):
             exc = task.exception()
             if exc is not None:
                 raise exc
@@ -570,7 +570,7 @@ async def run_app(app: Application) -> None:
         done, pending = await fut
         logger.debug("Exiting consumer")
         # re-raise any errors so we can validate during tests
-        for task in done | pending:
+        for task in (done + pending):
             exc = task.exception()
             if exc is not None:
                 raise exc

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -567,8 +567,13 @@ async def run_app(app: Application) -> None:
         fut = asyncio.create_task(app.consume_forever())
         for signame in {"SIGINT", "SIGTERM"}:
             loop.add_signal_handler(getattr(signal, signame), partial(_sig_handler, app))
-        await fut
+        done, pending = await fut
         logger.debug("Exiting consumer")
+        # re-raise any errors so we can validate during tests
+        for task in done | pending:
+            exc = task.exception()
+            if exc is not None:
+                raise exc
 
 
 def run(app: Optional[Application] = None) -> None:

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -496,7 +496,7 @@ class Application(Router):
         await self.stop()
 
         # re-raise any errors so we can validate during tests
-        for task in done | pending:
+        for task in done:
             exc = task.exception()
             if exc is not None:
                 raise exc
@@ -570,7 +570,7 @@ async def run_app(app: Application) -> None:
         done, pending = await fut
         logger.debug("Exiting consumer")
         # re-raise any errors so we can validate during tests
-        for task in done | pending:
+        for task in done:
             exc = task.exception()
             if exc is not None:
                 raise exc

--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -496,7 +496,7 @@ class Application(Router):
         await self.stop()
 
         # re-raise any errors so we can validate during tests
-        for task in (done + pending):
+        for task in done | pending:
             exc = task.exception()
             if exc is not None:
                 raise exc
@@ -570,7 +570,7 @@ async def run_app(app: Application) -> None:
         done, pending = await fut
         logger.debug("Exiting consumer")
         # re-raise any errors so we can validate during tests
-        for task in (done + pending):
+        for task in done | pending:
             exc = task.exception()
             if exc is not None:
                 raise exc

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -283,6 +283,10 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
                     await self.on_handler_failed(exc, record)
                 else:
                     self._count_message(record)
+            except InvalidStateError:
+                # Task didnt finish yet, we shouldnt be here since we are
+                # iterating the `done` list, so just log something
+                logger.warning(f"Trying to get exception from unfinished task. Record: {record}")
             except asyncio.CancelledError:
                 # During task execution any exception will be returned in
                 # the `done` list. But timeout exception should be captured

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -283,7 +283,7 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
                     await self.on_handler_failed(exc, record)
                 else:
                     self._count_message(record)
-            except InvalidStateError:
+            except asyncio.InvalidStateError:
                 # Task didnt finish yet, we shouldnt be here since we are
                 # iterating the `done` list, so just log something
                 logger.warning(f"Trying to get exception from unfinished task. Record: {record}")

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -171,6 +171,8 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
                 except aiokafka.errors.KafkaConnectionError:
                     # We retry
                     await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            pass
         except StopConsumer:
             logger.info(f"Consumer {self} stopped, exiting")
         except BaseException as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.6.1"
+version = "0.6.3"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -316,7 +316,7 @@ class TestRun:
 
     async def test_run_app(self):
         app_mock = AsyncMock()
-        app_mock.consume_forever.return_value = ([], [])
+        app_mock.consume_forever.return_value = (set(), set())
         loop = MagicMock()
         with patch("kafkaesk.app.asyncio.get_event_loop", return_value=loop):
             await run_app(app_mock)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -316,6 +316,7 @@ class TestRun:
 
     async def test_run_app(self):
         app_mock = AsyncMock()
+        app_mock.consume_forever.return_value = ([], [])
         loop = MagicMock()
         with patch("kafkaesk.app.asyncio.get_event_loop", return_value=loop):
             await run_app(app_mock)


### PR DESCRIPTION
capture failed condition before stop the app, and raise it so the downstream dependency can manage the failure.