### PR TITLE
Commit lock and new api

### DIFF
--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -456,7 +456,7 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
             logger.info(f"Partitions assigned to {self}: {assigned}")
 
         for tp in assigned:
-            position = await consumer.position(partition)
+            position = await self._consumer.position(tp)
             self._tp[tp] = position
 
             CONSUMER_REBALANCED.labels(

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -47,7 +47,7 @@ class Subscription:
     ):
         self.consumer_id = consumer_id
         if self.pattern and self.topics:
-            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")
+            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")  # noqa
         self.pattern = pattern
         self.topics = topics
         self.func = func

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -278,7 +278,6 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
             else:
                 await self._consume_batch(batch)
 
-
     async def _consume_batch(
         self, batch: typing.Dict[TopicPartition, typing.List[aiokafka.ConsumerRecord]]
     ) -> None:

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -46,6 +46,8 @@ class Subscription:
         concurrency: int = None,
     ):
         self.consumer_id = consumer_id
+        if self.pattern and self.topics:
+            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")
         self.pattern = pattern
         self.topics = topics
         self.func = func

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -235,7 +235,9 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
         consumer = self._app.consumer_factory(self.group_id)
 
         if self.pattern and self.topics:
-            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")  # noqa
+            raise AssertionError(
+                "Both of the params 'pattern' and 'topics' are not allowed. Select only one mode."
+            )  # noqa
 
         if self.pattern:
             # This is needed in case we have a prefix

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -36,21 +36,25 @@ logger = logging.getLogger(__name__)
 class Subscription:
     def __init__(
         self,
-        stream_id: str,
+        consumer_id: str,
         func: typing.Callable,
         group: str,
         *,
+        pattern: typing.Optional[str] = None,
+        topics: typing.Optional[typing.List[str]] = None,
         timeout_seconds: float = None,
         concurrency: int = None,
     ):
-        self.stream_id = stream_id
+        self.consumer_id = consumer_id
+        self.pattern = pattern
+        self.topics = topics
         self.func = func
         self.group = group
         self.timeout = timeout_seconds
         self.concurrency = concurrency
 
     def __repr__(self) -> str:
-        return f"<Subscription stream: {self.stream_id} >"
+        return f"<Subscription stream: {self.consumer_id} >"
 
 
 def _pydantic_msg_handler(
@@ -131,6 +135,7 @@ def build_handler(
 
 
 class BatchConsumer(aiokafka.ConsumerRebalanceListener):
+    _subscription: Subscription
     _close: typing.Optional[asyncio.Future]
     _consumer: aiokafka.AIOKafkaConsumer
     _offsets: typing.Dict[aiokafka.TopicPartition, int]
@@ -140,27 +145,29 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
 
     def __init__(
         self,
-        stream_id: str,
-        group_id: str,
-        coro: typing.Callable,
+        subscription: Subscription,
         app: "Application",
         event_handlers: typing.Optional[typing.Dict[str, typing.List[typing.Callable]]] = None,
-        concurrency: int = 1,
-        timeout_seconds: float = None,
         auto_commit: bool = True,
     ):
         self._initialized = False
-        self.stream_id = stream_id
-        self.group_id = group_id
-        self._coro = coro
+        self.stream_id = subscription.consumer_id
+        self.group_id = subscription.group
+        self._coro = subscription.func
         self._event_handlers = event_handlers or {}
-        self._concurrency = concurrency
-        self._timeout = timeout_seconds
+        self._concurrency = subscription.concurrency or 1
+        self._timeout = subscription.timeout
+        self._subscription = subscription
         self._close = None
         self._app = app
         self._last_commit = 0
         self._auto_commit = auto_commit
         self._tp: typing.Dict[aiokafka.TopicPartition, int] = {}
+
+        # We accept either pattern or a list of topics, also we might accept a single topic
+        # to keep compatibility with older API
+        self.pattern = subscription.pattern
+        self.topics = subscription.topics
 
     async def __call__(self) -> None:
         if not self._initialized:
@@ -208,7 +215,6 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
         self._close = None
         self._running = True
         self._processing = asyncio.Lock()
-        await self._maybe_create_topic()
         self._consumer = await self._consumer_factory()
         await self._consumer.start()
         self._message_handler = build_handler(self._coro, self._app, self)  # type: ignore
@@ -227,14 +233,21 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
 
     async def _consumer_factory(self) -> aiokafka.AIOKafkaConsumer:
         consumer = self._app.consumer_factory(self.group_id)
-        # This is needed in case we have a prefix
-        topic_id = self._app.topic_mng.get_topic_id(self.stream_id)
 
-        if "*" in self.stream_id:
-            pattern = fnmatch.translate(topic_id)
-            consumer.subscribe(pattern=pattern, listener=self)
+        if self.pattern:
+            # This is needed in case we have a prefix
+            topic_id = self._app.topic_mng.get_topic_id(self.stream_id)
+
+            if "*" in self.pattern:
+                pattern = fnmatch.translate(topic_id)
+                consumer.subscribe(pattern=pattern, listener=self)
+            else:
+                consumer.subscribe(topics=[topic_id], listener=self)
+        elif self.topics:
+            topics = [self._app.topic_mng.get_topic_id(topic) for topic in self.topics]
+            consumer.subscribe(topics=topics, listener=self)
         else:
-            consumer.subscribe(topics=[topic_id], listener=self)
+            raise ValueError("Either `topics` or `pattern` should be defined")
 
         return consumer
 
@@ -380,12 +393,6 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
     @property
     def consumer(self) -> aiokafka.AIOKafkaConsumer:
         return self._consumer
-
-    async def _maybe_create_topic(self) -> None:
-        # TBD: should we manage this here?
-        return
-        if not await self._app.topic_mng.topic_exists(self.stream_id):
-            await self._app.topic_mng.create_topic(topic=self.stream_id)
 
     async def _maybe_commit(self, forced: bool = False) -> None:
         if not self._auto_commit:

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -236,7 +236,7 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
 
         if self.pattern:
             # This is needed in case we have a prefix
-            topic_id = self._app.topic_mng.get_topic_id(self.stream_id)
+            topic_id = self._app.topic_mng.get_topic_id(self.pattern)
 
             if "*" in self.pattern:
                 pattern = fnmatch.translate(topic_id)

--- a/kafkaesk/consumer.py
+++ b/kafkaesk/consumer.py
@@ -46,8 +46,6 @@ class Subscription:
         concurrency: int = None,
     ):
         self.consumer_id = consumer_id
-        if self.pattern and self.topics:
-            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")  # noqa
         self.pattern = pattern
         self.topics = topics
         self.func = func
@@ -235,6 +233,9 @@ class BatchConsumer(aiokafka.ConsumerRebalanceListener):
 
     async def _consumer_factory(self) -> aiokafka.AIOKafkaConsumer:
         consumer = self._app.consumer_factory(self.group_id)
+
+        if self.pattern and self.topics:
+            raise AssertionError("Both of the params 'pattern' and 'topics' are not allowed. Select only one mode.")  # noqa
 
         if self.pattern:
             # This is needed in case we have a prefix

--- a/poetry.lock
+++ b/poetry.lock
@@ -190,7 +190,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "4.2.0"
+version = "4.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -927,8 +927,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
-    {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
+    {file = "importlib_metadata-4.3.0-py3-none-any.whl", hash = "sha256:c8b9a7c6000baa7adf7abcd2c41db11f172bcb5d6e448c73c2407dbc7e7e2af3"},
+    {file = "importlib_metadata-4.3.0.tar.gz", hash = "sha256:c4646abbce80191bb548636f846e353ff1edc46a06bc536ea0a60d53211dc690"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.7.0"
+version = "0.7.1"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.7.1"
+version = "0.7.2"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [

--- a/tests/acceptance/test_rebalance.py
+++ b/tests/acceptance/test_rebalance.py
@@ -1,6 +1,6 @@
 from .produce import Foo
 from .produce import producer
-from kafkaesk.consumer import BatchConsumer
+from kafkaesk.consumer import BatchConsumer, Subscription
 
 import asyncio
 import kafkaesk
@@ -19,13 +19,16 @@ async def test_cancel_getone(app):
         pass
 
     async with app:
-        consumer = BatchConsumer(
-            stream_id=TOPIC,
-            group_id=GROUP,
-            coro=handler,
-            app=app,
-            concurrency=1,
+        subscription = Subscription(
+            "test_consumer",
+            handler,
+            GROUP,
+            topics=[TOPIC],
             timeout_seconds=1,
+        )
+        consumer = BatchConsumer(
+            subscription=subscription,
+            app=app,
         )
         await consumer.initialize()
         raw_consumer = consumer._consumer

--- a/tests/unit/test_consumer.py
+++ b/tests/unit/test_consumer.py
@@ -1,7 +1,7 @@
 from kafkaesk import Application
 from kafkaesk import Subscription
 from kafkaesk.consumer import build_handler
-from kafkaesk.consumer import BatchConsumer
+from kafkaesk.consumer import BatchConsumer, Subscription
 from kafkaesk.exceptions import ConsumerUnhealthyException
 from kafkaesk.exceptions import StopConsumer
 from tests.utils import record_factory
@@ -19,11 +19,21 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture()
-def subscription():
+def subscription_conf():
+    subscription = Subscription(
+        "foo",
+        lambda record: 1,
+        "group",
+        topics=["foo"],
+        timeout_seconds=1,
+    )
+    yield subscription
+
+
+@pytest.fixture()
+def subscription(subscription_conf):
     yield BatchConsumer(
-        stream_id="foo",
-        group_id="group",
-        coro=lambda record: 1,
+        subscription=subscription_conf,
         app=Application(kafka_servers=["foobar"]),
     )
 
@@ -85,24 +95,20 @@ class TestSubscriptionConsumer:
         with pytest.raises(ConsumerUnhealthyException):
             assert await subscription.healthy()
 
-    async def test_emit(self):
+    async def test_emit(self, subscription_conf):
         probe = AsyncMock()
 
         sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
+            subscription=subscription_conf,
             app=Application(kafka_servers=["foobar"]),
             event_handlers={"event": [probe]},
         )
         await sub.emit("event", "foo", "bar")
         probe.assert_called_with("foo", "bar")
 
-    async def test_emit_raises_stop(self):
+    async def test_emit_raises_stop(self, subscription_conf):
         sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
+            subscription=subscription_conf,
             app=Application(kafka_servers=["foobar"]),
             event_handlers={"event": [AsyncMock(side_effect=StopConsumer)]},
         )
@@ -110,61 +116,39 @@ class TestSubscriptionConsumer:
         with pytest.raises(StopConsumer):
             await sub.emit("event", "foo", "bar")
 
-    async def test_emit_swallow_ex(self):
+    async def test_emit_swallow_ex(self, subscription_conf):
         sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
+            subscription=subscription_conf,
             app=Application(kafka_servers=["foobar"]),
             event_handlers={"event": [AsyncMock(side_effect=Exception)]},
         )
 
         await sub.emit("event", "foo", "bar")
 
-    async def test_retries_on_connection_failure(self):
-        sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
-            app=Application(kafka_servers=["foobar"]),
-        )
-
+    async def test_retries_on_connection_failure(self, subscription):
         run_mock = AsyncMock()
         sleep = AsyncMock()
         run_mock.side_effect = [aiokafka.errors.KafkaConnectionError, StopConsumer]
-        sub._consumer = MagicMock()
-        with patch.object(sub, "initialize", AsyncMock()), patch.object(
-            sub, "finalize", AsyncMock()
-        ), patch.object(sub, "_consume", run_mock), patch("kafkaesk.consumer.asyncio.sleep", sleep):
-            await sub()
+        subscription._consumer = MagicMock()
+        with patch.object(subscription, "initialize", AsyncMock()), patch.object(
+            subscription, "finalize", AsyncMock()
+        ), patch.object(subscription, "_consume", run_mock), patch("kafkaesk.consumer.asyncio.sleep", sleep):
+            await subscription()
             sleep.assert_called_once()
             assert len(run_mock.mock_calls) == 2
 
-    async def test_finalize_handles_exceptions(self):
-        sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
-            app=Application(kafka_servers=["foobar"]),
-        )
-
+    async def test_finalize_handles_exceptions(self, subscription):
         consumer = AsyncMock()
         consumer.stop.side_effect = Exception
         consumer.commit.side_effect = Exception
 
-        sub._consumer = consumer
-        await sub.finalize()
+        subscription._consumer = consumer
+        await subscription.finalize()
 
         consumer.stop.assert_called_once()
 
-    async def test_run_exits_when_fut_closed_fut(self):
-        sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
-            app=Application(kafka_servers=["foobar"]),
-        )
-
+    async def test_run_exits_when_fut_closed_fut(self, subscription):
+        sub = subscription
         consumer = AsyncMock()
         consumer.getmany.return_value = {"": [record_factory() for _ in range(10)]}
         sub._consumer = consumer
@@ -182,11 +166,9 @@ class TestSubscriptionConsumer:
 
             await asyncio.wait([stop_task, task])
 
-    async def test_auto_commit_can_be_disabled(self):
+    async def test_auto_commit_can_be_disabled(self, subscription_conf):
         sub = BatchConsumer(
-            stream_id="foo",
-            group_id="group",
-            coro=lambda record: 1,
+            subscription=subscription_conf,
             app=Application(kafka_servers=["foobar"]),
             auto_commit=False,
         )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,6 +28,8 @@ async def test_record_metric_on_rebalance():
             coro,
             app_mock,
         )
+        rebalance_listener._consumer = AsyncMock()
+
         await rebalance_listener.on_partitions_assigned(
             [TopicPartition(topic="foobar", partition=0)]
         )

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,7 +1,7 @@
 from aiokafka.structs import OffsetAndMetadata
 from aiokafka.structs import TopicPartition
 from kafkaesk.app import Application
-from kafkaesk.consumer import BatchConsumer
+from kafkaesk.consumer import BatchConsumer, Subscription
 from tests.utils import record_factory
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -22,11 +22,17 @@ async def test_record_metric_on_rebalance():
         app_mock.topic_mng.list_consumer_group_offsets.return_value = {
             TopicPartition(topic="foobar", partition=0): OffsetAndMetadata(offset=0, metadata={})
         }
-        rebalance_listener = BatchConsumer(
-            "stream.foo",
-            "group",
+
+        subscription = Subscription(
+            "test_consumer",
             coro,
-            app_mock,
+            "group",
+            topics=["stream.foo"],
+        )
+
+        rebalance_listener = BatchConsumer(
+            subscription=subscription,
+            app=app_mock,
         )
         rebalance_listener._consumer = AsyncMock()
 


### PR DESCRIPTION
- New subscribe API
  - replicate aiokafka `topics` or `pattern` params
  - keep compatibility with the current subscribe api
- Refine commit logic, replicate what auto commit in aiokafka is doing, by getting the current offset after a rebalance, and commiting those offsets instead of waiting for new messages.