### PR TITLE
Compatibility with kafka >=0.13.0 (api_version)

### DIFF
--- a/kafkaesk/app.py
+++ b/kafkaesk/app.py
@@ -39,6 +39,10 @@ import pydantic
 import signal
 import time
 
+from packaging.version import Version
+
+_AIOKAFKA_SUPPORTS_API_VERSION = Version(aiokafka.__version__) < Version("0.13.0")
+
 logger = logging.getLogger("kafkaesk")
 
 
@@ -464,14 +468,17 @@ class Application(Router):
             return not self._producer._sender.sender_task.done()
         return True
 
+    def _api_version(self) -> Dict[str, Any]:
+        return {"api_version": self._kafka_api_version} if _AIOKAFKA_SUPPORTS_API_VERSION else {}
+
     def consumer_factory(self, group_id: str) -> aiokafka.AIOKafkaConsumer:
         return aiokafka.AIOKafkaConsumer(
             bootstrap_servers=cast(List[str], self._kafka_servers),
             loop=asyncio.get_event_loop(),
             group_id=group_id,
             auto_offset_reset="earliest",
-            api_version=self._kafka_api_version,
             enable_auto_commit=False,
+            **self._api_version(),
             **{k: v for k, v in self.kafka_settings.items() if k in _aiokafka_consumer_settings},
         )
 
@@ -479,7 +486,7 @@ class Application(Router):
         return aiokafka.AIOKafkaProducer(
             bootstrap_servers=cast(List[str], self._kafka_servers),
             loop=asyncio.get_event_loop(),
-            api_version=self._kafka_api_version,
+            **self._api_version(),
             **{k: v for k, v in self.kafka_settings.items() if k in _aiokafka_producer_settings},
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafkaesk"
-version = "0.8.6"
+version = "0.8.7"
 description = "Easy publish and subscribe to events with python and Kafka."
 authors = ["vangheem <vangheem@gmail.com>", "pfreixes <pfreixes@gmail.com>"]
 classifiers = [
@@ -15,6 +15,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.10.1"
 aiokafka = ">=0.7.1"
+packaging = ">=21.0"
 kafka-python = "^2.0.2"
 pydantic = ">=1.5.1"
 orjson = ">=3.3.1"


### PR DESCRIPTION
aiokafka 0.13.0 removed the api_version parameter, causing a hard TypeError at runtime for any service using kafkaesk with the newer version.

##Changes:
- Added a module-level flag using a version comparison (Version(aiokafka.__version__) < Version("0.13.0")) to detect whether the installed aiokafka supports api_version
- Extracted _api_version_kwargs() helper on Application to keep the factories clean
producer_factory and consumer_factory now conditionally include api_version only when supported